### PR TITLE
Remove deprecated "Encoding" in group "Desktop Entry"

### DIFF
--- a/desktop/iptux.desktop
+++ b/desktop/iptux.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=iptux
 Name[zh_CN]=信使(iptux)
 Name[zh_TW]=信使(iptux)


### PR DESCRIPTION
This patch has existed since the initial upload of iptux (0.4.1-0ubuntu1)
to Ubuntu jaunty in December 2008.

Yes, this is from `debian/patches/01-desktop_encoding.patch`  :-)
@lidaobing, Since you wrote the patch back in 2008, I used `--author="LI Daobing <lidaobing@gmail.com>"` when I ran `git commit`.  :wink: