### PR TITLE
Upgrade to GStreamer from 0.10 to 1.0

### DIFF
--- a/configure
+++ b/configure
@@ -6114,7 +6114,7 @@ else
 $as_echo "yes" >&6; }
 
 fi
-gst_modules="gstreamer-0.10 >= 0.10.0"
+gst_modules="gstreamer-1.0 >= 1.0"
 
 pkg_failed=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for GST" >&5
@@ -6190,8 +6190,8 @@ if test "${have_gst}" = yes ; then
 $as_echo "#define HAVE_GST 1" >>confdefs.h
 
 else
-{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: You need GStreamer-0.10 or later installed if you need sound relevant functions" >&5
-$as_echo "$as_me: WARNING: You need GStreamer-0.10 or later installed if you need sound relevant functions" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: You need GStreamer-1.0 or later installed if you need sound relevant functions" >&5
+$as_echo "$as_me: WARNING: You need GStreamer-1.0 or later installed if you need sound relevant functions" >&2;}
 fi
 PACKAGE_CFLAGS="${GLIB_CFLAGS} ${GTHREAD_CFLAGS} ${GTK_CFLAGS} ${GCONF_CFLAGS} ${GST_CFLAGS}"
 PACKAGE_LIBS="${GLIB_LIBS} ${GTHREAD_LIBS} ${GTK_LIBS} ${GCONF_LIBS} ${GST_LIBS}"

--- a/configure.ac
+++ b/configure.ac
@@ -113,12 +113,12 @@ gtk_modules="gtk+-2.0 >= 2.12.0"
 PKG_CHECK_MODULES(GTK, [$gtk_modules])
 gconf_modules="gconf-2.0 >= 2.4.0"
 PKG_CHECK_MODULES(GCONF, [$gconf_modules])
-gst_modules="gstreamer-0.10 >= 0.10.0"
+gst_modules="gstreamer-1.0 >= 1.0"
 PKG_CHECK_MODULES(GST, [$gst_modules], have_gst=yes, have_gst=no)
 if test "${have_gst}" = yes ; then
 AC_DEFINE(HAVE_GST)
 else
-AC_MSG_WARN(You need GStreamer-0.10 or later installed if you need sound relevant functions)
+AC_MSG_WARN(You need GStreamer-1.0 or later installed if you need sound relevant functions)
 fi
 PACKAGE_CFLAGS="${GLIB_CFLAGS} ${GTHREAD_CFLAGS} ${GTK_CFLAGS} ${GCONF_CFLAGS} ${GST_CFLAGS}"
 PACKAGE_LIBS="${GLIB_LIBS} ${GTHREAD_LIBS} ${GTK_LIBS} ${GCONF_LIBS} ${GST_LIBS}"

--- a/src/SoundSystem.cpp
+++ b/src/SoundSystem.cpp
@@ -132,7 +132,7 @@ void SoundSystem::LinkElement(GData **eltset, GstPad *pad)
         GstStructure *str;
         GstPad *spad;
 
-        caps = gst_pad_get_caps(pad);
+        caps = gst_pad_query_caps(pad, NULL);
         str = gst_caps_get_structure(caps, 0);
         volume = GST_ELEMENT(g_datalist_get_data(eltset, "volume-element"));
         if(strcasestr(gst_structure_get_name(str), "audio")


### PR DESCRIPTION
See Debian Bug #785847 https://bugs.debian.org/785847
"iptux: Please update to GStreamer 1.x" for rationale.

The following pages contain helpful information
for porting GStreamer from 0.10 to 1.0:

 * http://cgit.freedesktop.org/gstreamer/gstreamer/plain/docs/random/porting-to-1.0.txt
 * http://pkgs.fedoraproject.org/cgit/banshee.git/plain/Initial-port-to-GStreamer-1.0.patch?id2=HEAD

Fixes #11