### PR TITLE
Do not .gitignore *.patch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ modules.builtin
 *.gz
 *.bz2
 *.lzma
-*.patch
 *.gcno
 
 #
@@ -58,10 +57,6 @@ include/generated
 
 # stgit generated dirs
 patches-*
-
-# quilt's files
-patches
-series
 
 # cscope files
 cscope.*


### PR DESCRIPTION
Having "*.patch" in .gitignore ignores all debian/patches/*.patch
files and interfere with Debian packaging.