### PR TITLE
修复调整窗体大小时自动缩小的问题.

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -567,7 +567,7 @@ GtkWidget *MainWindow::CreateMainWindow()
                                  0.0, 0.0, GDK_GRAVITY_NORTH_WEST};
         GdkWindowHints hints = GdkWindowHints(GDK_HINT_MIN_SIZE |
                          GDK_HINT_MAX_SIZE | GDK_HINT_BASE_SIZE |
-                         GDK_HINT_RESIZE_INC | GDK_HINT_WIN_GRAVITY |
+                         /*GDK_HINT_RESIZE_INC |*/ GDK_HINT_WIN_GRAVITY |
                          GDK_HINT_USER_POS | GDK_HINT_USER_SIZE);
         GtkWidget *window;
         gint width, height;


### PR DESCRIPTION
实在看不下去了，为什么窗体自动缩小的问题迟迟不修复?
