### PR TITLE
Add gettext to cmake prefix under macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ script: mkdir build && cd build && cmake .. && make
 dist: trusty
 sudo: false
 install:
+  - '[ "$TRAVIS_OS_NAME" != osx ] || brew update'
   - '[ "$TRAVIS_OS_NAME" != osx ] || brew install gettext gtk+ gconf'
-  - '[ "$TRAVIS_OS_NAME" != osx ] || brew link gettext --force'
 
 addons:
   apt:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required (VERSION 3.1)
 project (iptux
 	VERSION 0.6.5)
 
+
+if (APPLE AND EXISTS /usr/local/opt/gettext)
+    list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/gettext")
+    set(CMAKE_EXE_LINKER_FLAGS "-L/usr/local/opt/gettext/lib")
+endif()
+
 include(GNUInstallDirs)
 include(FindPkgConfig)
 include(FindGettext)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ iptux
 
 ```
 brew install gettext gtk+ gconf cmake
-brew link gettext --force
 git clone git://github.com/iptux-src/iptux.git
 cd iptux
 mkdir build && cd build && cmake .. && make


### PR DESCRIPTION
Thus linking gettext into /usr/local is no longer needed.
A workaround for https://github.com/Homebrew/brew/issues/3299 is included.