### PR TITLE
under macosx, the about dialog will hang the app.

### DIFF
--- a/share/ui/ui.xml
+++ b/share/ui/ui.xml
@@ -21,7 +21,6 @@ ManPT &lt;pentie@gmail.com&gt;</property>
     <property name="logo_icon_name">iptux</property>
     <property name="license_type">gpl-2-0</property>
     <signal name="activate-link" handler="iptux_on_activate_link" swapped="no"/>
-    <signal name="delete-event" handler="gtk_widget_hide" swapped="no"/>
     <child>
       <placeholder/>
     </child>

--- a/src/iptux/MainWindow.cpp
+++ b/src/iptux/MainWindow.cpp
@@ -1525,6 +1525,7 @@ void MainWindow::onAbout(void*, void*, MainWindow&self) {
     CHECK_NOTNULL(gtk_builder_get_object(self.builder, "about_dialog"))
   );
   gtk_dialog_run(GTK_DIALOG(HelpDialog::AboutEntry(aboutDialog, GTK_WINDOW(self.window))));
+  gtk_widget_hide(GTK_WIDGET(aboutDialog));
 }
 
 /**

--- a/src/main/iptux.cpp
+++ b/src/main/iptux.cpp
@@ -152,7 +152,6 @@ int main(int argc, char** argv) {
   auto config = make_shared<IptuxConfig>(configPath);
   dealLog(*config);
 
-  gdk_threads_init();
   Application app(config);
   return app.run(argc, argv);
 }


### PR DESCRIPTION
remove gdk_threads_init resolve this problem.