### PR TITLE
Remove incorrect argument for i18n.merge_file

### DIFF
--- a/share/applications/meson.build
+++ b/share/applications/meson.build
@@ -1,5 +1,5 @@
 i18n = import('i18n')
-i18n.merge_file('io.github.iptux_src.iptux.desktop',
+i18n.merge_file(
     type: 'desktop',
     output: 'io.github.iptux_src.iptux.desktop',
     input: 'io.github.iptux_src.iptux.desktop.in',


### PR DESCRIPTION
`i18n.merge_file` has been ignoring positional arguments before and explicitly rejects with error "ERROR: Function does not take positional arguments" since meson 0.60.0