### PR TITLE
Fix dependency of libiptux_test

### DIFF
--- a/src/iptux/meson.build
+++ b/src/iptux/meson.build
@@ -104,6 +104,7 @@ test_sources = files([
     'UiHelperTest.cpp',
     'UiModelsTest.cpp',
 ])
+test_sources += [iptux_resource_h]
 libiptux_test = executable('libiptux_test',
     test_sources,
     dependencies: [gtk_dep, jsoncpp_dep, thread_dep, sigc_dep],


### PR DESCRIPTION
`iptux/IptuxResource.h` in custom target `iptux_resource_h` is also required in making executable `libiptux_test`. Absense of this target in source array of `libiptux_test` (`test_sources` in `meson.build`) causes that compiling of cpp sources of `libiptux_test` may begin before target `iptux_resource_h` is built, which leads to build failure.

`iptux/IptuxResource.h` is included in [`iptux/AboutDialogTest.cpp`](https://github.com/iptux-src/iptux/blob/daf69742bb57e6ac9a2e0cc8310d559d9d9bb20a/src/iptux/AboutDialogTest.cpp#L5)