### PR TITLE
#531 : reuse old style signal handler

### DIFF
--- a/src/main/iptux.cpp
+++ b/src/main/iptux.cpp
@@ -25,6 +25,7 @@
 
 #include <glib/gi18n.h>
 #include <glog/logging.h>
+#include <execinfo.h>
 
 #include "iptux/Application.h"
 
@@ -137,8 +138,27 @@ static void dealLog(const IptuxConfig& config) {
   }
 }
 
+static void segvHandler(int sig) {
+  void *array[99];
+  size_t size;
+
+  // get void*'s for all entries on the stack
+  size = backtrace(array, 99);
+
+  // print out all the frames to stderr
+  fprintf(stderr, "Error: signal %d:\n", sig);
+  backtrace_symbols_fd(array, size, STDERR_FILENO);
+  exit(1);
+}
+
+static void installCrashHandler() {
+  signal(SIGSEGV, segvHandler);
+  signal(SIGABRT, segvHandler);
+  signal(SIGTRAP, segvHandler);
+}
+
 int main(int argc, char** argv) {
-  google::InstallFailureSignalHandler();
+  installCrashHandler();
   setlocale(LC_ALL, "");
   bindtextdomain(GETTEXT_PACKAGE, __LOCALE_PATH);
   bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");


### PR DESCRIPTION
```
$ /usr/local/bin/iptux &
[1] 577181
$ kill -11 `pgrep iptux`
Error: signal 11:
$ /usr/local/bin/iptux(+0x4c772)[0x55a7bcf86772]
/lib/x86_64-linux-gnu/libc.so.6(+0x42520)[0x7ff0b8642520]
/lib/x86_64-linux-gnu/libc.so.6(__poll+0x4f)[0x7ff0b8718bcf]
/lib/x86_64-linux-gnu/libglib-2.0.so.0(+0xab1f6)[0x7ff0b8e311f6]
/lib/x86_64-linux-gnu/libglib-2.0.so.0(g_main_context_iteration+0x33)[0x7ff0b8dd93e3]
/lib/x86_64-linux-gnu/libgio-2.0.so.0(g_application_run+0x1a5)[0x7ff0b9000fb5]
/usr/local/bin/iptux(_ZN5iptux11Application3runEiPPc+0x46)[0x55a7bcf88426]
/usr/local/bin/iptux(main+0x307)[0x55a7bcf86b16]
/lib/x86_64-linux-gnu/libc.so.6(+0x29d90)[0x7ff0b8629d90]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80)[0x7ff0b8629e40]
/usr/local/bin/iptux(_start+0x25)[0x55a7bcf85f55]

[1]+  Exit 1                  /usr/local/bin/iptux
$ echo '/usr/local/bin/iptux(_ZN5iptux11Application3runEiPPc+0x46)[0x55a7bcf88426]' | c++filt
/usr/local/bin/iptux(iptux::Application::run(int, char**)+0x46)[0x55a7bcf88426]
```