### PR TITLE
#605: Ctrl-V should not paste text twice

### DIFF
--- a/src/iptux/DialogBase.cpp
+++ b/src/iptux/DialogBase.cpp
@@ -803,13 +803,7 @@ void DialogBase::OnPasteClipboard(DialogBase*, GtkTextView* textview) {
   buffer = gtk_text_view_get_buffer(textview);
   gtk_text_buffer_get_iter_at_mark(buffer, &iter,
                                    gtk_text_buffer_get_insert(buffer));
-  if (gtk_clipboard_wait_is_text_available(clipboard)) {
-    gchar* text = gtk_clipboard_wait_for_text(clipboard);
-    if (text) {
-      gtk_text_buffer_insert(buffer, &iter, text, -1);
-      g_free(text);
-    }
-  } else if (gtk_clipboard_wait_is_image_available(clipboard)) {
+  if (gtk_clipboard_wait_is_image_available(clipboard)) {
     GdkPixbuf* pixbuf = gtk_clipboard_wait_for_image(clipboard);
     if (pixbuf) {
       gtk_text_buffer_insert_pixbuf(buffer, &iter, pixbuf);

--- a/src/iptux/DialogPeer.cpp
+++ b/src/iptux/DialogPeer.cpp
@@ -501,7 +501,7 @@ void DialogPeer::onRequestSharedResources(void*, void*, DialogPeer& self) {
 
 void DialogPeer::onPaste(void*, void*, DialogPeer* self) {
   GtkTextView* textview = GTK_TEXT_VIEW(self->inputTextviewWidget);
-  DialogBase::OnPasteClipboard(self, textview);
+  g_signal_emit_by_name(textview, "paste-clipboard");
 }
 
 void DialogPeer::insertPicture() {

--- a/src/iptux/DialogPeerTest.cpp
+++ b/src/iptux/DialogPeerTest.cpp
@@ -24,6 +24,7 @@ TEST(DialogPeer, Constructor) {
   GroupInfo* grpinf = app->getCoreThread()->GetPalRegularItem(pal.get());
   grpinf->buffer = gtk_text_buffer_new(NULL);
   DialogPeer* dlgpr = new DialogPeer(app, grpinf);
+  ASSERT_EQ(igtk_text_buffer_get_text(grpinf->getInputBuffer()), "");
 
   auto clipboard = gtk_clipboard_get(GDK_SELECTION_CLIPBOARD);
   gtk_clipboard_set_text(clipboard, "hello world", -1);

--- a/src/iptux/DialogPeerTest.cpp
+++ b/src/iptux/DialogPeerTest.cpp
@@ -1,4 +1,5 @@
 #include "Application.h"
+#include "UiHelper.h"
 #include "gtest/gtest.h"
 
 #include "iptux-utils/TestHelper.h"
@@ -27,6 +28,7 @@ TEST(DialogPeer, Constructor) {
   auto clipboard = gtk_clipboard_get(GDK_SELECTION_CLIPBOARD);
   gtk_clipboard_set_text(clipboard, "hello world", -1);
   do_action(dlgpr, "paste");
+  ASSERT_EQ(igtk_text_buffer_get_text(grpinf->getInputBuffer()), "hello world");
 
   GError* error = NULL;
   auto pixbuf =

--- a/src/iptux/UiHelper.cpp
+++ b/src/iptux/UiHelper.cpp
@@ -376,4 +376,13 @@ GtkImage* igtk_image_new_with_size(const char* filename,
   return GTK_IMAGE(gtk_image_new_from_pixbuf(pixbuf));
 }
 
+string igtk_text_buffer_get_text(GtkTextBuffer* buffer) {
+  GtkTextIter start, end;
+  gtk_text_buffer_get_bounds(buffer, &start, &end);
+  char* res1 = gtk_text_buffer_get_text(buffer, &start, &end, FALSE);
+  string res(res1);
+  g_free(res1);
+  return res;
+}
+
 }  // namespace iptux

--- a/src/iptux/UiHelper.h
+++ b/src/iptux/UiHelper.h
@@ -37,6 +37,7 @@ GSList* selection_data_get_path(GtkSelectionData* data);
  * @return GtkImage* null if failed
  */
 GtkImage* igtk_image_new_with_size(const char* filename, int width, int height);
+std::string igtk_text_buffer_get_text(GtkTextBuffer* buffer);
 
 /**
  * @brief only used for test, after call this, pop_info, pop_warning,


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug where using Ctrl-V to paste text would result in the text being pasted twice. The text pasting logic was refactored to use the 'paste-clipboard' signal, and a new test was added to ensure correct functionality.

- **Bug Fixes**:
    - Fixed issue where pasting text using Ctrl-V would result in the text being pasted twice.
- **Enhancements**:
    - Refactored text pasting logic to use the 'paste-clipboard' signal for better consistency.
- **Tests**:
    - Added a test to verify that text is correctly pasted from the clipboard into the text buffer.

<!-- Generated by sourcery-ai[bot]: end summary -->