### PR TITLE
#600: fix locale problem in unittest

### DIFF
--- a/src/iptux/UiModelsTest.cpp
+++ b/src/iptux/UiModelsTest.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "iptux-utils/TestHelper.h"
+#include <clocale>
 #include <memory>
 #include <vector>
 
@@ -89,6 +90,7 @@ static string igtk_text_get_all_text(GtkTextBuffer* buffer) {
 }
 
 TEST(GroupInfo, addMsgPara) {
+  setlocale(LC_ALL, "C");
   PalInfo pal("127.0.0.1", 2425);
   pal.setVersion("1_iptux");
   pal.setName("palname");


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a locale-related issue in the unit tests by explicitly setting the locale to 'C' in the GroupInfo addMsgPara test.

- **Bug Fixes**:
    - Fixed locale issue in unit tests by setting locale to 'C' in the GroupInfo addMsgPara test.

<!-- Generated by sourcery-ai[bot]: end summary -->