### PR TITLE
Don't open url/path in unittest, only log it

### DIFF
--- a/src/iptux/ApplicationTest.cpp
+++ b/src/iptux/ApplicationTest.cpp
@@ -1,3 +1,4 @@
+#include "UiHelper.h"
 #include "gtest/gtest.h"
 
 #include "iptux/Application.h"
@@ -13,6 +14,7 @@ void do_action(Application* app, const string& name) {
 }
 
 TEST(Application, Constructor) {
+  _ForTestToggleOpenUrl(false);
   Application* app = CreateApplication();
   do_action(app, "help.whats_new");
   do_action(app, "tools.open_chat_log");

--- a/src/iptux/UiHelper.cpp
+++ b/src/iptux/UiHelper.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 #include "UiHelper.h"
 
+#include <atomic>
 #include <cerrno>
 #include <cstring>
 #include <ctime>

--- a/src/iptux/UiHelper.cpp
+++ b/src/iptux/UiHelper.cpp
@@ -15,6 +15,7 @@ using namespace std;
 
 namespace iptux {
 
+static atomic_bool open_url_enabled(true);
 static bool pop_disabled = false;
 
 void iptux_open_path(const char* path) {
@@ -28,12 +29,20 @@ void iptux_open_path(const char* path) {
     g_error_free(error);
     return;
   }
-  g_app_info_launch_default_for_uri(uri, nullptr, &error);
+  if (!open_url_enabled) {
+    LOG_INFO("iptux_open_path %s", path);
+  } else {
+    g_app_info_launch_default_for_uri(uri, nullptr, &error);
+  }
   if (error) {
     LOG_WARN(_("Can't open path: %s, reason: %s"), path, error->message);
     g_error_free(error);
   }
   g_free(uri);
+}
+
+void _ForTestToggleOpenUrl(bool enable) {
+  open_url_enabled = enable;
 }
 
 /**
@@ -49,7 +58,11 @@ void iptux_open_url(const char* url) {
   }
 
   GError* error = nullptr;
-  g_app_info_launch_default_for_uri(url, nullptr, &error);
+  if (!open_url_enabled) {
+    LOG_INFO("iptux_open_url %s", url);
+  } else {
+    g_app_info_launch_default_for_uri(url, nullptr, &error);
+  }
   if (error) {
     LOG_WARN(_("Can't open URL: %s, reason: %s"), url, error->message);
     g_error_free(error);

--- a/src/iptux/UiHelper.h
+++ b/src/iptux/UiHelper.h
@@ -48,6 +48,7 @@ void pop_info(GtkWidget* parent, const gchar* format, ...) G_GNUC_PRINTF(2, 3);
 void pop_warning(GtkWidget* parent, const gchar* format, ...)
     G_GNUC_PRINTF(2, 3);
 void iptux_open_url(const char* url);
+void _ForTestToggleOpenUrl(bool enable);
 
 std::string ipv4_get_lan_name(in_addr ipv4);
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduced a mechanism to disable URL opening in tests by adding a toggle function and updating the test cases to use this function.

- **Tests**:
    - Added a toggle function to disable URL opening in tests to prevent actual URL launches during test execution.

<!-- Generated by sourcery-ai[bot]: end summary -->