### PR TITLE
#624: remove deprecated

### DIFF
--- a/src/iptux/DialogBase.cpp
+++ b/src/iptux/DialogBase.cpp
@@ -305,8 +305,6 @@ GtkWidget* DialogBase::CreateHistoryArea() {
                    G_CALLBACK(textview_event_after), NULL);
   g_signal_connect(chat_history_widget, "motion-notify-event",
                    G_CALLBACK(textview_motion_notify_event), NULL);
-  g_signal_connect(chat_history_widget, "visibility-notify-event",
-                   G_CALLBACK(textview_visibility_notify_event), NULL);
   g_signal_connect_data(grpinf->buffer, "insert-child-anchor",
                         G_CALLBACK(DialogBase::OnChatHistoryInsertChildAnchor),
                         this, NULL,

--- a/src/iptux/MainWindow.cpp
+++ b/src/iptux/MainWindow.cpp
@@ -690,7 +690,6 @@ GtkWidget* MainWindow::CreatePaltreeTree(GtkTreeModel* model) {
   g_object_set_data(G_OBJECT(view), "info-column", column);
   /* 展开器区域 */
   cell = gtk_cell_renderer_pixbuf_new();
-  g_object_set(cell, "follow-state", TRUE, NULL);
   gtk_tree_view_column_pack_start(column, cell, FALSE);
   gtk_tree_view_column_set_attributes(
       GTK_TREE_VIEW_COLUMN(column), cell, "pixbuf",
@@ -753,7 +752,6 @@ GtkWidget* MainWindow::CreatePallistTree(GtkTreeModel* model) {
   gtk_tree_view_column_set_resizable(column, TRUE);
   gtk_tree_view_column_set_title(column, _("Nickname"));
   cell = gtk_cell_renderer_pixbuf_new();
-  g_object_set(cell, "follow-state", TRUE, NULL);
   gtk_tree_view_column_pack_start(column, cell, FALSE);
   gtk_tree_view_column_set_attributes(column, cell, "pixbuf", 0, NULL);
   cell = gtk_cell_renderer_text_new();

--- a/src/iptux/callback.cpp
+++ b/src/iptux/callback.cpp
@@ -305,20 +305,4 @@ gboolean textview_motion_notify_event(GtkWidget* textview,
   return FALSE;
 }
 
-gboolean textview_visibility_notify_event(GtkWidget* textview,
-                                          GdkEventVisibility*) {
-  gint wx, wy, bx, by;
-
-  auto window = gtk_widget_get_window(textview);
-  auto display = gdk_window_get_display(window);
-  auto seat = gdk_display_get_default_seat(display);
-  auto device = gdk_seat_get_pointer(seat);
-  gdk_window_get_device_position(window, device, &wx, &wy, NULL);
-  gtk_text_view_window_to_buffer_coords(
-      GTK_TEXT_VIEW(textview), GTK_TEXT_WINDOW_WIDGET, wx, wy, &bx, &by);
-  textview_set_cursor_if_appropriate(GTK_TEXT_VIEW(textview), bx, by);
-
-  return FALSE;
-}
-
 }  // namespace iptux


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Removed deprecated functions and properties from the codebase, including `textview_visibility_notify_event` and the `follow-state` property of `gtk_cell_renderer_pixbuf`.

<!-- Generated by sourcery-ai[bot]: end summary -->