### PR TITLE
#627: fix wrap mode

### DIFF
--- a/src/iptux/DialogBase.cpp
+++ b/src/iptux/DialogBase.cpp
@@ -252,7 +252,7 @@ GtkWidget* DialogBase::CreateInputArea() {
 
   widget = gtk_text_view_new_with_buffer(grpinf->getInputBuffer());
   inputTextviewWidget = GTK_TEXT_VIEW(widget);
-  gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(widget), GTK_WRAP_WORD);
+  gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(widget), GTK_WRAP_WORD_CHAR);
   gtk_drag_dest_add_uri_targets(widget);
   gtk_container_add(GTK_CONTAINER(sw), widget);
   g_signal_connect_swapped(widget, "drag-data-received",
@@ -297,7 +297,7 @@ GtkWidget* DialogBase::CreateHistoryArea() {
       GTK_TEXT_VIEW(gtk_text_view_new_with_buffer(grpinf->buffer));
   gtk_text_view_set_cursor_visible(chat_history_widget, FALSE);
   gtk_text_view_set_editable(chat_history_widget, FALSE);
-  gtk_text_view_set_wrap_mode(chat_history_widget, GTK_WRAP_WORD);
+  gtk_text_view_set_wrap_mode(chat_history_widget, GTK_WRAP_WORD_CHAR);
   gtk_container_add(GTK_CONTAINER(sw), GTK_WIDGET(chat_history_widget));
   g_signal_connect(chat_history_widget, "key-press-event",
                    G_CALLBACK(textview_key_press_event), NULL);

--- a/src/iptux/DialogPeer.cpp
+++ b/src/iptux/DialogPeer.cpp
@@ -317,7 +317,7 @@ GtkWidget* DialogPeer::CreateInfoArea() {
   widget = gtk_text_view_new_with_buffer(buffer);
   gtk_text_view_set_cursor_visible(GTK_TEXT_VIEW(widget), FALSE);
   gtk_text_view_set_editable(GTK_TEXT_VIEW(widget), FALSE);
-  gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(widget), GTK_WRAP_NONE);
+  gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(widget), GTK_WRAP_WORD_CHAR);
   gtk_container_add(GTK_CONTAINER(sw), widget);
   g_datalist_set_data(&widset, "info-textview-widget", widget);
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses an issue with the text wrapping mode in various text view widgets within the application. The wrapping mode has been updated to 'GTK_WRAP_WORD_CHAR' to ensure proper handling of both words and characters.

- **Bug Fixes**:
    - Fixed text wrapping mode in input, history, and info areas to ensure proper word and character wrapping.

<!-- Generated by sourcery-ai[bot]: end summary -->