### PR TITLE
check exist preference dialog before open a new one (fix #644)

### DIFF
--- a/src/iptux/Application.h
+++ b/src/iptux/Application.h
@@ -40,6 +40,9 @@ class Application {
   PPalInfo getMe();
   GMenuModel* menu() { return menu_; }
 
+  GtkWidget* getPreferenceDialog() { return preference_dialog_; }
+  void setPreferenceDialog(GtkWidget* dialog) { preference_dialog_ = dialog; }
+
  private:
   std::shared_ptr<IptuxConfig> config;
   std::shared_ptr<ProgramData> data;
@@ -58,6 +61,7 @@ class Application {
   LogSystem* logSystem = 0;
   NotificationService* notificationService = 0;
   GMenuModel* menu_ = 0;
+  GtkWidget* preference_dialog_ = 0;
   bool use_header_bar_ = false;
   bool started{false};
 

--- a/src/iptux/DataSettings.cpp
+++ b/src/iptux/DataSettings.cpp
@@ -68,8 +68,14 @@ DataSettings::~DataSettings() {
  * @param parent 父窗口指针
  */
 void DataSettings::ResetDataEntry(Application* app, GtkWidget* parent) {
+  if (app->getPreferenceDialog()) {
+    gtk_window_present(GTK_WINDOW(app->getPreferenceDialog()));
+    return;
+  }
+
   DataSettings dset(app, parent);
   GtkWidget* dialog = GTK_WIDGET(dset.dialog());
+  app->setPreferenceDialog(dialog);
 
   /* 运行对话框 */
   gtk_widget_show_all(dialog);
@@ -98,6 +104,7 @@ void DataSettings::ResetDataEntry(Application* app, GtkWidget* parent) {
         break;
     }
   }
+  app->setPreferenceDialog(NULL);
 }
 
 /**


### PR DESCRIPTION
/close #644 

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where multiple preference dialogs could be opened at the same time.