### PR TITLE
disable LTO(Link Time Optimization) for UI test

### DIFF
--- a/src/iptux/meson.build
+++ b/src/iptux/meson.build
@@ -116,7 +116,9 @@ test_sources += [iptux_resource_h]
 libiptux_test = executable('libiptux_test',
     test_sources,
     dependencies: [gtk_dep, jsoncpp_dep, thread_dep, sigc_dep],
+    cpp_args: ['-fno-lto'], # https://github.com/iptux-src/iptux/issues/651
     link_with: [libiptux, libgtest,libiptux_core_test_helper],
+    link_args: ['-fno-lto'],
     include_directories: [inc, gtest_inc]
 )
 


### PR DESCRIPTION
/close #651

## Summary by Sourcery

Bug Fixes:
- Disabled link time optimization (LTO) for UI tests to resolve a test failure.