### PR TITLE
fix iptux stackoverflow when receiving dir

### DIFF
--- a/src/iptux-core/internal/AnalogFS.cpp
+++ b/src/iptux-core/internal/AnalogFS.cpp
@@ -126,7 +126,7 @@ int AnalogFS::stat(const char* fn, struct ::stat* st) {
  * @param mode as in mkdir()
  * @return 成功与否
  */
-int AnalogFS::mkdir(const char* dir, mode_t mode) {
+int AnalogFS::makeDir(const char* dir, mode_t mode) {
   char tpath[MAX_PATHLEN];
   int result;
 

--- a/src/iptux-core/internal/AnalogFS.h
+++ b/src/iptux-core/internal/AnalogFS.h
@@ -30,7 +30,7 @@ class AnalogFS {
   int open(const char* fn, int flags);
   int open(const char* fn, int flags, mode_t mode);
   int stat(const char* fn, struct ::stat* st);
-  int mkdir(const char* dir, mode_t mode);
+  int makeDir(const char* dir, mode_t mode);
   int64_t ftwsize(const char* dir);
   DIR* opendir(const char* dir);
 

--- a/src/iptux-core/internal/RecvFileData.cpp
+++ b/src/iptux-core/internal/RecvFileData.cpp
@@ -214,7 +214,7 @@ void RecvFileData::RecvDirFiles() {
   }
   /* 转到文件存档目录 */
   g_free(ipmsg_get_filename_me(file->filepath, &pathname));
-  afs.mkdir(pathname, 0777);
+  afs.makeDir(pathname, 0777);
   afs.chdir(pathname);
   g_free(pathname);
 
@@ -267,7 +267,7 @@ void RecvFileData::RecvDirFiles() {
         }
         continue;
       case IPMSG_FILE_DIR:
-        afs.mkdir(dirname, 0777);
+        afs.makeDir(dirname, 0777);
         afs.chdir(dirname);
         if (len)
           memmove(buf, buf + headsize, len);


### PR DESCRIPTION
/close #472 

`g_mkdir` is macro define to `mkidr`, so when we call g_mkdir in  `AnalogFS::mkdir`, it will call itself. cause stackoverflow.

## Summary by Sourcery

Bug Fixes:
- Fixed a stack overflow error that occurred when creating directories during file transfer. The issue was caused by inadvertently calling `mkdir` recursively.