### PR TITLE
snapcraft: port to core22

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ version: "git" # just for humans, typically '1.2+git' or '1.3.2'
 adopt-info: iptux
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
-base: core20
+base: core22
 
 slots:
   dbus-iptux:
@@ -15,7 +15,7 @@ apps:
   iptux:
     command: usr/bin/iptux
     desktop: usr/share/applications/io.github.iptux_src.iptux.desktop
-    extensions: [gnome-3-38]
+    extensions: [gnome]
     slots:
       - dbus-iptux
     plugs: [home, network, gsettings, unity7]
@@ -49,9 +49,8 @@ parts:
     stage-packages:
       - libgflags2.2
       - libgoogle-glog0v5
-      - libjsoncpp1
+      - libjsoncpp25
       - libsigc++-2.0-0v5
       - libayatana-appindicator3-1
-      - try:
-          - libunwind8 # not available in s390x
+      - libunwind8
     parse-info: [usr/share/metainfo/io.github.iptux_src.iptux.metainfo.xml]


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the snapcraft base to core22 and the gnome extension from gnome-3-38 to gnome. Update the libjsoncpp1 stage package to libjsoncpp25 and add libunwind8 to all architectures, removing the s390x workaround