### PR TITLE
meson: use so_version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ if get_option('sanitize-address')
   add_project_link_arguments('-fsanitize=address', language: 'cpp')
 endif
 
-so_version = '0.9.3'
+so_version = 1
 subdir('src')
 subdir('share')
 subdir('po')

--- a/src/iptux-core/meson.build
+++ b/src/iptux-core/meson.build
@@ -47,13 +47,14 @@ else
         link_with: [libiptux_utils],
         include_directories: inc,
         install: true,
-        version: so_version,
+        version: meson.project_version(),
+        soversion: so_version,
     )
     pkg = import('pkgconfig')
     pkg.generate(
         description: 'Communicate and Share File in LAN',
         name: 'iptux-core',
-        version: so_version,
+        version: meson.project_version(),
         requires: [jsoncpp_dep, glib_dep, sigc_dep, thread_dep],
         requires_private: [glog_dep, gflags_dep],
         libraries: [libiptux_core, glog_dep],


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Set the library `soversion` to 1 and use `meson.project_version()` for the `version` field in the pkg-config file and library target