### PR TITLE
Bug fix: dialog ui position/size error when repeat open/close.

### DIFF
--- a/src/iptux/Application.cpp
+++ b/src/iptux/Application.cpp
@@ -80,7 +80,7 @@ Application::Application(shared_ptr<IptuxConfig> config)
   notificationService = new TerminalNotifierNoticationService();
 #else
   notificationService = new GioNotificationService();
-  use_header_bar_ = true;
+  // use_header_bar_ = true;
   // GError* error = nullptr;
   // if(!g_application_register(G_APPLICATION(app), nullptr, &error)) {
   //   LOG_WARN("g_application_register failed: %s-%d-%s",

--- a/src/iptux/DialogPeer.cpp
+++ b/src/iptux/DialogPeer.cpp
@@ -274,8 +274,8 @@ GtkWidget* DialogPeer::CreateAllArea() {
   gtk_paned_pack1(GTK_PANED(hpaned), vpaned, TRUE, TRUE);
   g_signal_connect(vpaned, "notify::position", G_CALLBACK(PanedDivideChanged),
                    &dtset);
-  gtk_paned_pack1(GTK_PANED(vpaned), CreateHistoryArea(), TRUE, TRUE);
-  gtk_paned_pack2(GTK_PANED(vpaned), CreateInputArea(), FALSE, TRUE);
+  gtk_paned_pack1(GTK_PANED(vpaned), CreateHistoryArea(), FALSE, TRUE);
+  gtk_paned_pack2(GTK_PANED(vpaned), CreateInputArea(), TRUE, TRUE);
   /* 加入好友信息&附件区域 */
   vpaned = gtk_paned_new(GTK_ORIENTATION_VERTICAL);
   g_object_set_data(G_OBJECT(vpaned), "position-name",
@@ -286,8 +286,8 @@ GtkWidget* DialogPeer::CreateAllArea() {
   gtk_paned_pack2(GTK_PANED(hpaned), vpaned, FALSE, TRUE);
   g_signal_connect(vpaned, "notify::position", G_CALLBACK(PanedDivideChanged),
                    &dtset);
-  gtk_paned_pack1(GTK_PANED(vpaned), CreateInfoArea(), TRUE, TRUE);
-  gtk_paned_pack2(GTK_PANED(vpaned), CreateFileArea(), FALSE, TRUE);
+  gtk_paned_pack1(GTK_PANED(vpaned), CreateInfoArea(), FALSE, TRUE);
+  gtk_paned_pack2(GTK_PANED(vpaned), CreateFileArea(), TRUE, TRUE);
 
   return box;
 }
@@ -510,8 +510,8 @@ GtkWidget* DialogPeer::CreateFileArea() {
   g_signal_connect(vpaned, "notify::position", G_CALLBACK(PanedDivideChanged),
                    &dtset);
   gtk_container_add(GTK_CONTAINER(frame), vpaned);
-  gtk_paned_pack1(GTK_PANED(vpaned), CreateFileReceiveArea(), TRUE, TRUE);
-  gtk_paned_pack2(GTK_PANED(vpaned), CreateFileSendArea(), FALSE, TRUE);
+  gtk_paned_pack1(GTK_PANED(vpaned), CreateFileReceiveArea(), FALSE, TRUE);
+  gtk_paned_pack2(GTK_PANED(vpaned), CreateFileSendArea(), TRUE, TRUE);
   return frame;
 }
 
@@ -531,7 +531,7 @@ GtkWidget* DialogPeer::CreateFileReceiveArea() {
   gtk_paned_set_position(GTK_PANED(vpaned), position);
   g_signal_connect(vpaned, "notify::position", G_CALLBACK(PanedDivideChanged),
                    &dtset);
-  gtk_paned_pack1(GTK_PANED(vpaned), CreateFileToReceiveArea(), TRUE, FALSE);
+  gtk_paned_pack1(GTK_PANED(vpaned), CreateFileToReceiveArea(), FALSE, FALSE);
   gtk_paned_pack2(GTK_PANED(vpaned), CreateFileReceivedArea(), TRUE, FALSE);
   return vpaned;
 }


### PR DESCRIPTION
1. DialogPeer will create title bar when 'use_header_bar_' enabled, and the new height value will be store into config which callback from 'WindowConfigureEvent', so when repeatly open/close dialog, the dialog height will get higher and higher.

2. divider position in dialog will move upward.

Note:
I dont known if there are issues on other platforms, but it seems work correctly in my machine.

**My Os:** 
OS: Linux Mint 22.1 x86_64 (base on Ubuntu 24.04)
DE: Cinnamon 6.4.6

## Summary by Sourcery

Fix dialog layout issues causing incorrect height and divider positioning.

Bug Fixes:
- Disable the header bar feature to prevent dialog height from increasing on repeated open/close.
- Adjust pane resizing flags to correct divider positioning within dialogs.