### PR TITLE
Bug fix: ui position/size error when repeat open/close

### DIFF
--- a/src/iptux/DialogBase.cpp
+++ b/src/iptux/DialogBase.cpp
@@ -517,11 +517,13 @@ void DialogBase::DragDataReceived(DialogBase* dlgpr,
  * @param dtset data set
  * @return Gtk+库所需
  */
-gboolean DialogBase::WindowConfigureEvent(GtkWidget*,
+gboolean DialogBase::WindowConfigureEvent(GtkWidget* window,
                                           GdkEventConfigure* event,
                                           GData** dtset) {
-  g_datalist_set_data(dtset, "window-width", GINT_TO_POINTER(event->width));
-  g_datalist_set_data(dtset, "window-height", GINT_TO_POINTER(event->height));
+  int width, height;
+  gtk_window_get_size(GTK_WINDOW(window), &width, &height);
+  g_datalist_set_data(dtset, "window-width", GINT_TO_POINTER(width));
+  g_datalist_set_data(dtset, "window-height", GINT_TO_POINTER(height));
 
   return FALSE;
 }

--- a/src/iptux/DialogPeer.cpp
+++ b/src/iptux/DialogPeer.cpp
@@ -274,8 +274,8 @@ GtkWidget* DialogPeer::CreateAllArea() {
   gtk_paned_pack1(GTK_PANED(hpaned), vpaned, TRUE, TRUE);
   g_signal_connect(vpaned, "notify::position", G_CALLBACK(PanedDivideChanged),
                    &dtset);
-  gtk_paned_pack1(GTK_PANED(vpaned), CreateHistoryArea(), TRUE, TRUE);
-  gtk_paned_pack2(GTK_PANED(vpaned), CreateInputArea(), FALSE, TRUE);
+  gtk_paned_pack1(GTK_PANED(vpaned), CreateHistoryArea(), FALSE, TRUE);
+  gtk_paned_pack2(GTK_PANED(vpaned), CreateInputArea(), TRUE, TRUE);
   /* 加入好友信息&附件区域 */
   vpaned = gtk_paned_new(GTK_ORIENTATION_VERTICAL);
   g_object_set_data(G_OBJECT(vpaned), "position-name",
@@ -286,8 +286,8 @@ GtkWidget* DialogPeer::CreateAllArea() {
   gtk_paned_pack2(GTK_PANED(hpaned), vpaned, FALSE, TRUE);
   g_signal_connect(vpaned, "notify::position", G_CALLBACK(PanedDivideChanged),
                    &dtset);
-  gtk_paned_pack1(GTK_PANED(vpaned), CreateInfoArea(), TRUE, TRUE);
-  gtk_paned_pack2(GTK_PANED(vpaned), CreateFileArea(), FALSE, TRUE);
+  gtk_paned_pack1(GTK_PANED(vpaned), CreateInfoArea(), FALSE, TRUE);
+  gtk_paned_pack2(GTK_PANED(vpaned), CreateFileArea(), TRUE, TRUE);
 
   return box;
 }
@@ -510,8 +510,8 @@ GtkWidget* DialogPeer::CreateFileArea() {
   g_signal_connect(vpaned, "notify::position", G_CALLBACK(PanedDivideChanged),
                    &dtset);
   gtk_container_add(GTK_CONTAINER(frame), vpaned);
-  gtk_paned_pack1(GTK_PANED(vpaned), CreateFileReceiveArea(), TRUE, TRUE);
-  gtk_paned_pack2(GTK_PANED(vpaned), CreateFileSendArea(), FALSE, TRUE);
+  gtk_paned_pack1(GTK_PANED(vpaned), CreateFileReceiveArea(), FALSE, TRUE);
+  gtk_paned_pack2(GTK_PANED(vpaned), CreateFileSendArea(), TRUE, TRUE);
   return frame;
 }
 
@@ -531,7 +531,7 @@ GtkWidget* DialogPeer::CreateFileReceiveArea() {
   gtk_paned_set_position(GTK_PANED(vpaned), position);
   g_signal_connect(vpaned, "notify::position", G_CALLBACK(PanedDivideChanged),
                    &dtset);
-  gtk_paned_pack1(GTK_PANED(vpaned), CreateFileToReceiveArea(), TRUE, FALSE);
+  gtk_paned_pack1(GTK_PANED(vpaned), CreateFileToReceiveArea(), FALSE, FALSE);
   gtk_paned_pack2(GTK_PANED(vpaned), CreateFileReceivedArea(), TRUE, FALSE);
   return vpaned;
 }

--- a/src/iptux/MainWindow.cpp
+++ b/src/iptux/MainWindow.cpp
@@ -1616,11 +1616,13 @@ void MainWindow::PallistDragDataReceived(GtkWidget* treeview,
  * @param dtset data set
  * @return Gtk+库所需
  */
-gboolean MainWindow::MWinConfigureEvent(GtkWidget*,
+gboolean MainWindow::MWinConfigureEvent(GtkWidget* window,
                                         GdkEventConfigure* event,
                                         MainWindow* self) {
-  self->windowConfig.SetWidth(event->width)
-      .SetHeight(event->height)
+  int width, height;
+  gtk_window_get_size(GTK_WINDOW(window), &width, &height);
+  self->windowConfig.SetWidth(width)
+      .SetHeight(height)
       .SaveToConfig(self->config);
   return FALSE;
 }


### PR DESCRIPTION
1. replace get width/height from event by gtk_window_get_size when window changed to fix window height getting higher and highter if repeat open/close this window.

2. adjust frame resize flag to fix the divider will move upward.

@see
https://docs.gtk.org/gtk3/method.Window.set_default_size.html#description

If you use this function to reestablish a previously saved window size, note that the appropriate size to save is the one returned by gtk_window_get_size(). Using the window allocation directly will not work in all circumstances and can lead to growing or shrinking windows.

## Summary by Sourcery

Fix UI issues related to window resizing and pane divider positioning.

Bug Fixes:
- Correct window size retrieval using `gtk_window_get_size` to prevent windows growing on repeated open/close.
- Adjust GTK paned packing parameters to fix divider positioning when resizing.