### PR TITLE
Enable -fsanitize=undefined in meson option, and fix found bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: >-
           brew install --display-times ${{ env.MAC_PKGS }}
       - name: meson
-        run: meson setup build
+        run: meson setup -Dsanitize-address=true -Dsanitize-undefined=true build
       - name: build
         run: meson compile -C build
       - name: install
@@ -60,7 +60,7 @@ jobs:
       - name: meson
         run: |
           meson --version
-          meson setup build
+          meson setup -Dsanitize-address=true -Dsanitize-undefined=true build
         env:
           CXX: ${{ matrix.compiler }}
       - name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: sudo meson install -C build
       - name: test
         run: |
-          xvfb-run -a meson test -C build --verbose --no-stdsplit
+          ASAN_OPTIONS=detect_leaks=0 xvfb-run -a meson test -C build --verbose --no-stdsplit
 
   codecov:
     runs-on: ubuntu-latest

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,10 @@ if get_option('sanitize-address')
   add_project_arguments('-fsanitize=address', language: 'cpp')
   add_project_link_arguments('-fsanitize=address', language: 'cpp')
 endif
+if get_option('sanitize-undefined')
+  add_project_arguments('-fsanitize=undefined', language: 'cpp')
+  add_project_link_arguments('-fsanitize=undefined', language: 'cpp')
+endif
 
 so_version = 1
 subdir('src')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -25,3 +25,10 @@ option(
   value: false,
   description: 'enable -fsanitize=address compile/link flag',
 )
+
+option(
+  'sanitize-undefined',
+  type: 'boolean',
+  value: false,
+  description: 'enable -fsanitize=undefined compile/link flag',
+)

--- a/src/iptux-core/TransFileModel.cpp
+++ b/src/iptux-core/TransFileModel.cpp
@@ -108,6 +108,9 @@ std::string TransFileModel::getFinishedLengthText() const {
 }
 
 double TransFileModel::getProgress() const {
+  if (fileLength <= 0) {
+    return 0.0;  // Avoid division by zero
+  }
   return percent(finishedLength, fileLength);
 }
 

--- a/src/iptux-core/internal/UdpData.cpp
+++ b/src/iptux-core/internal/UdpData.cpp
@@ -55,12 +55,6 @@ UdpData::UdpData(CoreThread& coreThread,
   }
 }
 
-UdpData::UdpData(const string& buf_, const string& ipv4String)
-    : coreThread(*(CoreThread*)NULL), size(buf_.size()), encode(nullptr) {
-  this->ipv4 = inAddrFromString(ipv4String);
-  memcpy(buf, &buf_[0], buf_.size());
-}
-
 /**
  * 类析构函数.
  */

--- a/src/iptux-core/internal/UdpData.h
+++ b/src/iptux-core/internal/UdpData.h
@@ -25,7 +25,6 @@ namespace iptux {
 class UdpData {
  public:
   UdpData(CoreThread& coreThread, in_addr ipv4, const char buf[], size_t size);
-  UdpData(const std::string& buf, const std::string& ipv4String);
   ~UdpData();
 
   in_addr getIpv4() const { return ipv4; }

--- a/src/iptux-core/internal/UdpDataTest.cpp
+++ b/src/iptux-core/internal/UdpDataTest.cpp
@@ -8,5 +8,7 @@ using namespace std;
 using namespace iptux;
 
 TEST(UdpData, getCommandNo) {
-  ASSERT_EQ(UdpData("", "127.0.0.1").getCommandNo(), 0);
+  auto coreThread = newCoreThread();
+  UdpData data(*coreThread, inAddrFromString("127.0.0.1"), "", 0);
+  ASSERT_EQ(data.getCommandNo(), 0);
 }

--- a/src/iptux/Application.cpp
+++ b/src/iptux/Application.cpp
@@ -116,13 +116,13 @@ void Application::activate() {
 }
 
 void Application::onStartup(Application& self) {
+  self.data = make_shared<ProgramData>(self.config);
+  self.cthrd = make_shared<UiCoreThread>(&self, self.data);
   init_theme(&self);
   iptux_register_resource();
   self.menuBuilder =
       gtk_builder_new_from_resource(IPTUX_RESOURCE "gtk/menus.ui");
-  self.data = make_shared<ProgramData>(self.config);
   self.logSystem = new LogSystem(self.data);
-  self.cthrd = make_shared<UiCoreThread>(&self, self.data);
   if (self.enable_app_indicator_) {
     self.app_indicator = make_shared<IptuxAppIndicator>(&self);
   }

--- a/src/iptux/MainWindow.cpp
+++ b/src/iptux/MainWindow.cpp
@@ -389,7 +389,7 @@ void MainWindow::LoadConfig() {
 
   GtkSortType sort_type;
   if (GtkSortTypeFromStr(this->config->GetString(config_names[CFG_SORT_TYPE]),
-                         &sort_type)) {
+                         sort_type)) {
     this->sort_type_ = sort_type;
   }
 
@@ -1064,7 +1064,7 @@ void MainWindow::onSortType(GSimpleAction* action,
   string sortType = g_variant_get_string(value, nullptr);
   GtkSortType sort_type;
 
-  if (!GtkSortTypeFromStr(sortType, &sort_type)) {
+  if (!GtkSortTypeFromStr(sortType, sort_type)) {
     LOG_WARN("unknown sort type: %s", sortType.c_str());
     return;
   }

--- a/src/iptux/MainWindow.cpp
+++ b/src/iptux/MainWindow.cpp
@@ -387,9 +387,9 @@ void MainWindow::LoadConfig() {
     this->info_style_ = info_style;
   }
 
-  GtkSortType sort_type =
-      GtkSortTypeFromStr(this->config->GetString(config_names[CFG_SORT_TYPE]));
-  if (sort_type != GTK_SORT_TYPE_INVALID) {
+  GtkSortType sort_type;
+  if (GtkSortTypeFromStr(this->config->GetString(config_names[CFG_SORT_TYPE]),
+                         &sort_type)) {
     this->sort_type_ = sort_type;
   }
 
@@ -1062,10 +1062,10 @@ void MainWindow::onSortType(GSimpleAction* action,
                             GVariant* value,
                             MainWindow& self) {
   string sortType = g_variant_get_string(value, nullptr);
-  GtkSortType sort_type = GtkSortTypeFromStr(sortType);
+  GtkSortType sort_type;
 
-  if (sort_type == GTK_SORT_TYPE_INVALID) {
-    LOG_WARN("unknown sorttype: %s", sortType.c_str());
+  if (!GtkSortTypeFromStr(sortType, &sort_type)) {
+    LOG_WARN("unknown sort type: %s", sortType.c_str());
     return;
   }
   self.sort_type_ = sort_type;

--- a/src/iptux/TestHelper.cpp
+++ b/src/iptux/TestHelper.cpp
@@ -11,6 +11,7 @@ Application* CreateApplication() {
   gtk_init(nullptr, nullptr);
   auto config = newTestIptuxConfig();
   Application* app = new Application(config);
+  app->set_enable_app_indicator(false);
   app->startup();
   // g_application_register(G_APPLICATION(app->getApp()), nullptr, nullptr);
   // auto i = g_application_get_is_registered(G_APPLICATION(app->getApp()));

--- a/src/iptux/TestHelper.cpp
+++ b/src/iptux/TestHelper.cpp
@@ -11,6 +11,7 @@ Application* CreateApplication() {
   gtk_init(nullptr, nullptr);
   auto config = newTestIptuxConfig();
   Application* app = new Application(config);
+  app->startup();
   // g_application_register(G_APPLICATION(app->getApp()), nullptr, nullptr);
   // auto i = g_application_get_is_registered(G_APPLICATION(app->getApp()));
   // EXPECT_TRUE(i);

--- a/src/iptux/UiModels.cpp
+++ b/src/iptux/UiModels.cpp
@@ -355,13 +355,14 @@ static const char* gtk_sort_type_names[] = {
     [GTK_SORT_DESCENDING] = "descending",
 };
 
-GtkSortType GtkSortTypeFromStr(const std::string& s) {
+bool GtkSortTypeFromStr(const std::string& s, GtkSortType* outType) {
   for (int i = GTK_SORT_ASCENDING; i <= GTK_SORT_DESCENDING; ++i) {
     if (s == gtk_sort_type_names[i]) {
-      return (GtkSortType)i;
+      *outType = (GtkSortType)i;
+      return true;
     }
   }
-  return GTK_SORT_TYPE_INVALID;
+  return false;
 }
 const char* GtkSortTypeToStr(GtkSortType t) {
   if (GTK_SORT_ASCENDING <= t && t <= GTK_SORT_DESCENDING) {

--- a/src/iptux/UiModels.cpp
+++ b/src/iptux/UiModels.cpp
@@ -355,10 +355,10 @@ static const char* gtk_sort_type_names[] = {
     [GTK_SORT_DESCENDING] = "descending",
 };
 
-bool GtkSortTypeFromStr(const std::string& s, GtkSortType* outType) {
+bool GtkSortTypeFromStr(const std::string& s, GtkSortType& outType) {
   for (int i = GTK_SORT_ASCENDING; i <= GTK_SORT_DESCENDING; ++i) {
     if (s == gtk_sort_type_names[i]) {
-      *outType = (GtkSortType)i;
+      outType = (GtkSortType)i;
       return true;
     }
   }

--- a/src/iptux/UiModels.h
+++ b/src/iptux/UiModels.h
@@ -53,7 +53,7 @@ enum class GroupInfoStyle {
 GroupInfoStyle GroupInfoStyleFromStr(const std::string& s);
 const char* GroupInfoStyleToStr(GroupInfoStyle style);
 
-bool GtkSortTypeFromStr(const std::string& s, GtkSortType* outType);
+bool GtkSortTypeFromStr(const std::string& s, GtkSortType& outType);
 const char* GtkSortTypeToStr(GtkSortType t);
 
 class GroupInfo {

--- a/src/iptux/UiModels.h
+++ b/src/iptux/UiModels.h
@@ -53,8 +53,7 @@ enum class GroupInfoStyle {
 GroupInfoStyle GroupInfoStyleFromStr(const std::string& s);
 const char* GroupInfoStyleToStr(GroupInfoStyle style);
 
-const GtkSortType GTK_SORT_TYPE_INVALID = (GtkSortType)-1;
-GtkSortType GtkSortTypeFromStr(const std::string& s);
+bool GtkSortTypeFromStr(const std::string& s, GtkSortType* outType);
 const char* GtkSortTypeToStr(GtkSortType t);
 
 class GroupInfo {


### PR DESCRIPTION
## Summary by Sourcery

Refactor sort type parsing and client startup sequence; add undefined-behavior sanitizer support; guard against zero-length transfers; and ensure application startup is called in tests.

Bug Fixes:
- Prevent division by zero in TransFileModel::getProgress by returning 0.0 when file length is non-positive.

Enhancements:
- Refactor GtkSortTypeFromStr to use a boolean result with an output parameter and update its callers.
- Reorder Application startup to initialize ProgramData and UiCoreThread before building the UI.

Build:
- Add 'sanitize-undefined' Meson build option to enable -fsanitize=undefined flags.

Tests:
- Invoke Application::startup in TestHelper to ensure proper initialization during tests.