### PR TITLE
Ci mac fail2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 env:
   DEB_PKGS: >-
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Configure Homebrew cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/Library/Caches/Homebrew

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
   schedule:
     - cron: '33 11 * * 6'
 


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub workflows to use the ‘main’ branch and upgrade the Homebrew cache action version

CI:
- Change CI and CodeQL workflows to trigger on the ‘main’ branch instead of ‘master’
- Bump Homebrew cache action from actions/cache@v2 to actions/cache@v4