### PR TITLE
don't crash if `cthrd->GetTransTaskStat` return NULL

### DIFF
--- a/src/iptux/Application.cpp
+++ b/src/iptux/Application.cpp
@@ -334,6 +334,10 @@ void Application::onEvent(shared_ptr<const Event> _event) {
     g_assert(event);
     auto taskId = event->GetTaskId();
     auto para = cthrd->GetTransTaskStat(taskId);
+    if (!para) {
+      LOG_WARN("got task id %d, but no info in CoreThread", taskId);
+      return;
+    }
     this->updateItemToTransTree(*para);
     return;
   }


### PR DESCRIPTION
## Summary by Sourcery

Prevent crashes when retrieving transaction task status returns null by adding a guard and logging a warning

Bug Fixes:
- Add null check for GetTransTaskStat return value to avoid dereferencing a null pointer
- Log a warning and return early when no task info is found in CoreThread