### PR TITLE
Fix Application does not free process_event_source when free

### DIFF
--- a/src/iptux/Application.h
+++ b/src/iptux/Application.h
@@ -64,6 +64,7 @@ class Application {
   GtkWidget* preference_dialog_ = 0;
   bool use_header_bar_ = false;
   bool started{false};
+  guint process_events_source_id{0};
 
  public:
   // for test


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure the GLib process events source is removed when the Application instance is destroyed to avoid a lingering event callback.