### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('iptux', 'cpp',
     license: 'GPL2+',
-    version: '0.9.4',
+    version: '0.10.0',
     meson_version: '>=0.53',
     default_options: ['warning_level=2', 'cpp_std=c++17', 'werror=true'])
 
@@ -21,7 +21,7 @@ if host_machine.system() == 'darwin' and get_option('werror')
   add_project_arguments('-U_LIBCPP_ENABLE_ASSERTIONS', language: 'cpp')
 endif
 
-so_version = 1
+so_version = 2
 subdir('src')
 subdir('share')
 subdir('po')


### PR DESCRIPTION
## Summary by Sourcery

Update project metadata to release version 0.10.0 with a new shared library ABI version.

Build:
- Bump project version from 0.9.4 to 0.10.0 in Meson build configuration.
- Increment shared library so_version from 1 to 2 to reflect ABI change.