### PR TITLE
#705: fix snap build failed

### DIFF
--- a/src/iptux/AppIndicator.cpp
+++ b/src/iptux/AppIndicator.cpp
@@ -32,8 +32,15 @@ class IptuxAppIndicatorPrivate {
 
 IptuxAppIndicator::IptuxAppIndicator(Application* app) {
   this->priv = std::make_shared<IptuxAppIndicatorPrivate>(app);
+
+  // app_indicator_new is deprecated since 0.5.94, and prefer
+  // libayatana-appindicator-glib-dev, but unfortunately it's still not stable
+  // enough.
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
   priv->indicator = app_indicator_new("io.github.iptux_src.iptux", "iptux-icon",
                                       APP_INDICATOR_CATEGORY_COMMUNICATIONS);
+  G_GNUC_END_IGNORE_DEPRECATIONS
+
   app_indicator_set_status(priv->indicator, APP_INDICATOR_STATUS_ACTIVE);
   app_indicator_set_attention_icon_full(priv->indicator, "iptux-attention",
                                         "iptux-attention");


### PR DESCRIPTION
## Summary by Sourcery

Silence deprecation warnings around appindicator initialization to restore compatibility with the snap build.

Bug Fixes:
- Resolve snap build failures caused by deprecation warnings from appindicator initialization.

Build:
- Adjust appindicator usage to avoid deprecation-related build failures in snap packaging.