### PR TITLE
optimize snap config

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,7 +18,7 @@ apps:
     extensions: [gnome]
     slots:
       - dbus-iptux
-    plugs: [home, network, gsettings, unity7]
+    plugs: [home, network, gsettings]
 
 parts:
   iptux:
@@ -35,13 +35,7 @@ parts:
         appstream,
       ]
     plugin: meson
-    meson-parameters: ["--prefix=/snap/iptux/current/usr"]
-    override-pull: |
-      craftctl default
-    override-build: |
-      craftctl default
-    organize:
-      snap/iptux/current/usr: usr
+    meson-parameters: ["--prefix=/usr"]
     stage-packages:
       - libjsoncpp25
       - libsigc++-2.0-0v5


### PR DESCRIPTION
## Summary by Sourcery

Update snap packaging configuration for the iptux application.

Build:
- Adjust snapcraft meson install prefix to /usr and simplify build overrides and organize steps.
- Remove the unity7 plug from the iptux snap application definition.