### PR TITLE
Decouple the app indicator from the Application class

### DIFF
--- a/src/iptux/AppIndicator.cpp
+++ b/src/iptux/AppIndicator.cpp
@@ -4,14 +4,11 @@
 #include <glib/gi18n.h>
 #include <libayatana-appindicator/app-indicator.h>
 
-#include "iptux/Application.h"
-#include "iptux/UiCoreThread.h"
-
 namespace iptux {
 
 class IptuxAppIndicatorPrivate {
  public:
-  IptuxAppIndicatorPrivate(Application* app) : app(app) {}
+  IptuxAppIndicatorPrivate(IptuxAppIndicator* owner) : owner(owner) {}
   ~IptuxAppIndicatorPrivate() {
     if (indicator) {
       g_object_unref(indicator);
@@ -20,18 +17,17 @@ class IptuxAppIndicatorPrivate {
       g_object_unref(menuBuilder);
     }
   }
-  Application* app;
+  IptuxAppIndicator* owner;
   AppIndicator* indicator;
   GtkBuilder* menuBuilder;
 
   static void onScrollEvent(IptuxAppIndicatorPrivate* self) {
-    g_action_group_activate_action(G_ACTION_GROUP(self->app->getApp()),
-                                   "open_main_window", NULL);
+    self->owner->sigActivateMainWindow.emit();
   }
 };
 
-IptuxAppIndicator::IptuxAppIndicator(Application* app) {
-  this->priv = std::make_shared<IptuxAppIndicatorPrivate>(app);
+IptuxAppIndicator::IptuxAppIndicator(GActionGroup* action_group) {
+  this->priv = std::make_shared<IptuxAppIndicatorPrivate>(this);
 
   // app_indicator_new is deprecated since 0.5.94, and prefer
   // libayatana-appindicator-glib-dev, but unfortunately it's still not stable
@@ -52,16 +48,12 @@ IptuxAppIndicator::IptuxAppIndicator(Application* app) {
 
   GtkMenu* menu = GTK_MENU(gtk_menu_new_from_model(G_MENU_MODEL(
       gtk_builder_get_object(priv->menuBuilder, "app-indicator-menu"))));
-  gtk_widget_insert_action_group(GTK_WIDGET(menu), "app",
-                                 G_ACTION_GROUP(app->getApp()));
+  gtk_widget_insert_action_group(GTK_WIDGET(menu), "app", action_group);
   app_indicator_set_menu(priv->indicator, menu);
 
   g_signal_connect_swapped(priv->indicator, "scroll-event",
                            G_CALLBACK(IptuxAppIndicatorPrivate::onScrollEvent),
                            priv.get());
-
-  app->getCoreThread()->sigUnreadMsgCountUpdated.connect(
-      sigc::mem_fun(*this, &IptuxAppIndicator::SetUnreadCount));
 }
 
 void IptuxAppIndicator::SetUnreadCount(int i) {

--- a/src/iptux/AppIndicator.h
+++ b/src/iptux/AppIndicator.h
@@ -1,13 +1,18 @@
 #pragma once
 
-#include "iptux/Application.h"
+#include <gio/gio.h>
+#include <sigc++/sigc++.h>
+
+#include <memory>
 
 namespace iptux {
 class IptuxAppIndicatorPrivate;
 class IptuxAppIndicator {
  public:
-  IptuxAppIndicator(Application* app);
+  IptuxAppIndicator(GActionGroup* action_group);
   void SetUnreadCount(int count);
+
+  sigc::signal<void> sigActivateMainWindow;
 
  private:
   std::shared_ptr<IptuxAppIndicatorPrivate> priv;

--- a/src/iptux/AppIndicatorDummy.cpp
+++ b/src/iptux/AppIndicatorDummy.cpp
@@ -1,7 +1,11 @@
 #include "AppIndicator.h"
 
 namespace iptux {
-IptuxAppIndicator::IptuxAppIndicator(Application*) {
+IptuxAppIndicator::IptuxAppIndicator(GActionGroup*) {
+  // Dummy implementation
+}
+
+void IptuxAppIndicator::SetUnreadCount(int) {
   // Dummy implementation
 }
 }  // namespace iptux

--- a/src/iptux/Application.cpp
+++ b/src/iptux/Application.cpp
@@ -126,7 +126,14 @@ void Application::onStartup(Application& self) {
   self.menuBuilder =
       gtk_builder_new_from_resource(IPTUX_RESOURCE "gtk/menus.ui");
   if (self.enable_app_indicator_) {
-    self.app_indicator = make_shared<IptuxAppIndicator>(&self);
+    self.app_indicator =
+        make_shared<IptuxAppIndicator>(G_ACTION_GROUP(self.app));
+    self.app_indicator->sigActivateMainWindow.connect([&self]() {
+      g_action_group_activate_action(G_ACTION_GROUP(self.app),
+                                     "open_main_window", NULL);
+    });
+    self.cthrd->sigUnreadMsgCountUpdated.connect(
+        sigc::mem_fun(*self.app_indicator, &IptuxAppIndicator::SetUnreadCount));
   }
 
   bool use_app_menu = true;


### PR DESCRIPTION
## Summary by Sourcery

Decouple the app indicator from the Application class by routing actions and signals through a generic GActionGroup and a new activation signal.

Enhancements:
- Refactor IptuxAppIndicator to hold a reference to its owner and expose a sigActivateMainWindow signal instead of directly depending on Application and UiCoreThread.
- Update Application startup logic to wire the app indicator to the application action group and unread message count via signal connections.
- Adjust the dummy app indicator implementation to match the new constructor and method signatures.