### PR TITLE
support show/hide status icon

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ Version 0.10.0
 Released: 2026-XX-XX
 
 Features:
+  * Add status icon mode setting in Preferences (no icon, normal, blinking).
   * [#711] Add macOS menu bar status item (NSStatusItem) with system tray icon.
 
 Version 0.9.4

--- a/src/api/iptux-core/ProgramData.h
+++ b/src/api/iptux-core/ProgramData.h
@@ -7,6 +7,7 @@
 
 #include "iptux-core/IptuxConfig.h"
 #include "iptux-core/Models.h"
+#include "iptux-core/StatusIconMode.h"
 
 namespace iptux {
 
@@ -53,6 +54,8 @@ class ProgramData {
   bool IsUsingBlacklist() const;
   bool IsFilterFileShareRequest() const;
   bool isHideTaskbarWhenMainWindowIconified() const;
+  int statusIconMode() const;
+  void setStatusIconMode(int value);
   void set_port(uint16_t port, bool is_init = false);
   void setOpenChat(bool value) { open_chat = value; }
   void setHideStartup(bool value) { hide_startup = value; }
@@ -108,6 +111,7 @@ class ProgramData {
   uint8_t proof_shared : 1;
   uint8_t hide_taskbar_when_main_window_iconified_ : 1;
   uint8_t need_restart_ : 1;
+  uint8_t status_icon_mode_ : 2;
 
  private:
   void InitSublayer();

--- a/src/api/iptux-core/StatusIconMode.h
+++ b/src/api/iptux-core/StatusIconMode.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+namespace iptux {
+
+enum StatusIconMode {
+  STATUS_ICON_MODE_NONE = 0,
+  STATUS_ICON_MODE_NORMAL = 1,
+  STATUS_ICON_MODE_BLINKING = 2,
+};
+
+}  // namespace iptux

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -22,6 +22,12 @@
 #mesondefine SYSTEM_DARWIN
 #mesondefine HAVE_APPINDICATOR
 
+#if SYSTEM_DARWIN || HAVE_APPINDICATOR
+#define HAVE_STATUS_ICON 1
+#else
+#define HAVE_STATUS_ICON 0
+#endif
+
 #if defined(__APPLE__) || defined(__CYGWIN__)
 #define O_LARGEFILE 0
 #endif

--- a/src/iptux-core/ProgramData.cpp
+++ b/src/iptux-core/ProgramData.cpp
@@ -69,6 +69,7 @@ void ProgramData::WriteProgData() {
   config->SetBool("proof_shared", proof_shared);
   config->SetBool("hide_taskbar_when_main_window_iconified",
                   hide_taskbar_when_main_window_iconified_);
+  config->SetInt("status_icon_mode", status_icon_mode_);
   config->SetString("access_shared_limit", passwd);
   config->SetInt("send_message_retry_in_us", send_message_retry_in_us);
   WriteNetSegment();
@@ -144,6 +145,7 @@ void ProgramData::ReadProgData() {
   proof_shared = config->GetBool("proof_shared");
   hide_taskbar_when_main_window_iconified_ =
       config->GetBool("hide_taskbar_when_main_window_iconified");
+  status_icon_mode_ = config->GetInt("status_icon_mode", STATUS_ICON_MODE_NORMAL);
 
   passwd = config->GetString("access_shared_limit");
   send_message_retry_in_us =
@@ -243,6 +245,14 @@ bool ProgramData::isHideTaskbarWhenMainWindowIconified() const {
 #else
   return false;
 #endif
+}
+
+int ProgramData::statusIconMode() const {
+  return status_icon_mode_;
+}
+
+void ProgramData::setStatusIconMode(int value) {
+  status_icon_mode_ = value;
 }
 
 ProgramData& ProgramData::SetUsingBlacklist(bool value) {

--- a/src/iptux/AppIndicator.cpp
+++ b/src/iptux/AppIndicator.cpp
@@ -20,6 +20,8 @@ class IptuxAppIndicatorPrivate {
   IptuxAppIndicator* owner;
   AppIndicator* indicator;
   GtkBuilder* menuBuilder;
+  StatusIconMode mode = STATUS_ICON_MODE_NORMAL;
+  int unreadCount = 0;
 
   static void onScrollEvent(IptuxAppIndicatorPrivate* self) {
     self->owner->sigActivateMainWindow.emit();
@@ -57,10 +59,21 @@ IptuxAppIndicator::IptuxAppIndicator(GActionGroup* action_group) {
 }
 
 void IptuxAppIndicator::SetUnreadCount(int i) {
+  priv->unreadCount = i;
+  if (priv->mode == STATUS_ICON_MODE_NONE) return;
   if (i > 0) {
     app_indicator_set_status(priv->indicator, APP_INDICATOR_STATUS_ATTENTION);
   } else {
     app_indicator_set_status(priv->indicator, APP_INDICATOR_STATUS_ACTIVE);
+  }
+}
+
+void IptuxAppIndicator::SetMode(StatusIconMode mode) {
+  priv->mode = mode;
+  if (mode == STATUS_ICON_MODE_NONE) {
+    app_indicator_set_status(priv->indicator, APP_INDICATOR_STATUS_PASSIVE);
+  } else {
+    SetUnreadCount(priv->unreadCount);
   }
 }
 

--- a/src/iptux/AppIndicator.h
+++ b/src/iptux/AppIndicator.h
@@ -5,12 +5,15 @@
 
 #include <memory>
 
+#include "iptux-core/StatusIconMode.h"
+
 namespace iptux {
 class IptuxAppIndicatorPrivate;
 class IptuxAppIndicator {
  public:
   IptuxAppIndicator(GActionGroup* action_group);
   void SetUnreadCount(int count);
+  void SetMode(StatusIconMode mode);
 
   sigc::signal<void> sigActivateMainWindow;
 

--- a/src/iptux/AppIndicatorDummy.cpp
+++ b/src/iptux/AppIndicatorDummy.cpp
@@ -8,4 +8,8 @@ IptuxAppIndicator::IptuxAppIndicator(GActionGroup*) {
 void IptuxAppIndicator::SetUnreadCount(int) {
   // Dummy implementation
 }
+
+void IptuxAppIndicator::SetMode(StatusIconMode) {
+  // Dummy implementation
+}
 }  // namespace iptux

--- a/src/iptux/AppIndicatorMac.mm
+++ b/src/iptux/AppIndicatorMac.mm
@@ -130,6 +130,8 @@ class IptuxAppIndicatorPrivate {
   IptuxStatusItemHelper* helper = nil;
   NSImage* normalIcon = nil;
   NSImage* attentionIcon = nil;
+  StatusIconMode mode = STATUS_ICON_MODE_NORMAL;
+  int unreadCount = 0;
 };
 
 IptuxAppIndicator::IptuxAppIndicator(GActionGroup* action_group) {
@@ -185,12 +187,22 @@ IptuxAppIndicator::IptuxAppIndicator(GActionGroup* action_group) {
 }
 
 void IptuxAppIndicator::SetUnreadCount(int count) {
-  if (!priv->statusItem) return;
+  priv->unreadCount = count;
+  if (!priv->statusItem || priv->mode == STATUS_ICON_MODE_NONE) return;
 
   if (count > 0 && priv->attentionIcon) {
     priv->statusItem.button.image = priv->attentionIcon;
   } else if (priv->normalIcon) {
     priv->statusItem.button.image = priv->normalIcon;
+  }
+}
+
+void IptuxAppIndicator::SetMode(StatusIconMode mode) {
+  priv->mode = mode;
+  if (!priv->statusItem) return;
+  priv->statusItem.visible = (mode != STATUS_ICON_MODE_NONE);
+  if (mode != STATUS_ICON_MODE_NONE) {
+    SetUnreadCount(priv->unreadCount);
   }
 }
 

--- a/src/iptux/Application.cpp
+++ b/src/iptux/Application.cpp
@@ -128,6 +128,7 @@ void Application::onStartup(Application& self) {
   if (self.enable_app_indicator_) {
     self.app_indicator =
         make_shared<IptuxAppIndicator>(G_ACTION_GROUP(self.app));
+    self.app_indicator->SetMode(StatusIconMode(self.data->statusIconMode()));
     self.app_indicator->sigActivateMainWindow.connect([&self]() {
       g_action_group_activate_action(G_ACTION_GROUP(self.app),
                                      "open_main_window", NULL);
@@ -391,6 +392,9 @@ void Application::onConfigChanged() {
     add_accelerator(app, "win.send_message", "Return");
   } else {
     add_accelerator(app, "win.send_message", "<Primary>Return");
+  }
+  if (app_indicator) {
+    app_indicator->SetMode(StatusIconMode(data->statusIconMode()));
   }
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Add configurable status icon display modes and wire them through application settings, persistence, and app indicator implementations.

New Features:
- Introduce a status icon mode enumeration supporting disabling, normal, and blinking status icon behaviors.
- Expose a status icon mode selector in system settings and persist the chosen mode in program configuration.
- Apply the configured status icon mode to app indicators on Linux and macOS, including the ability to hide the status icon entirely.

Enhancements:
- Ensure app indicator unread-count handling respects the selected status icon mode and avoids updating when the icon is disabled.