### PR TITLE
fix snap build problem

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,8 +35,11 @@ parts:
         appstream,
       ]
     plugin: meson
-    meson-parameters: ["--prefix=/usr"]
+    meson-parameters: ["--prefix=/snap/iptux/current/usr"]
+    organize:
+      snap/iptux/current/usr: usr
     stage-packages:
+      - glib-networking
       - libjsoncpp25
       - libsigc++-2.0-0v5
       - libayatana-appindicator3-1


### PR DESCRIPTION
## Summary by Sourcery

Adjust snap packaging configuration to resolve build and runtime issues in the snap.

Build:
- Update snapcraft Meson installation prefix and file organization for the iptux part.
- Include glib-networking in the snap stage packages to ensure required networking libraries are available.