### PR TITLE
Bf fix snap 2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,8 +35,11 @@ parts:
         appstream,
       ]
     plugin: meson
-    meson-parameters: ["--prefix=/usr"]
+    meson-parameters: ["--prefix=/snap/iptux/current/usr"]
+    organize:
+      snap/iptux/current/usr: usr
     stage-packages:
+      - glib-networking
       - libjsoncpp25
       - libsigc++-2.0-0v5
       - libayatana-appindicator3-1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,6 +5,10 @@ grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 base: core24
 
+layout:
+  /usr/share/iptux:
+    bind: $SNAP/usr/share/iptux
+
 slots:
   dbus-iptux:
     interface: dbus
@@ -35,9 +39,7 @@ parts:
         appstream,
       ]
     plugin: meson
-    meson-parameters: ["--prefix=/snap/iptux/current/usr"]
-    organize:
-      snap/iptux/current/usr: usr
+    meson-parameters: ["--prefix=/usr"]
     stage-packages:
       - glib-networking
       - libjsoncpp25

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,9 +39,7 @@ parts:
         appstream,
       ]
     plugin: meson
-    meson-parameters: ["--prefix=/snap/iptux/current/usr"]
-    organize:
-      snap/iptux/current/usr: usr
+    meson-parameters: ["--prefix=/usr"]
     stage-packages:
       - glib-networking
       - libjsoncpp25


### PR DESCRIPTION
## Summary by Sourcery

Adjust snap packaging layout and installation prefix for iptux.

Enhancements:
- Bind /usr/share/iptux in the snap layout to the snap’s usr/share directory to align paths.
- Update Meson installation prefix to /usr and simplify snap part organization for the iptux build.