### PR TITLE
Changed git clone url from git: to https:

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ brew install iptux
 
 ```sh
 sudo apt-get install git libgtk-3-dev libglib2.0-dev libjsoncpp-dev g++ meson libsigc++-2.0-dev libayatana-appindicator3-dev appstream gettext
-git clone git://github.com/iptux-src/iptux.git
+git clone https://github.com/iptux-src/iptux.git
 cd iptux
 meson setup build
 meson compile -C build # or "ninja -C build" if meson version < 0.54
@@ -42,7 +42,7 @@ iptux
 
 ```sh
 brew install meson gettext gtk+3 jsoncpp gtk-mac-integration libsigc++@2 appstream
-git clone git://github.com/iptux-src/iptux.git
+git clone https://github.com/iptux-src/iptux.git
 cd iptux
 meson setup build
 meson install -C build


### PR DESCRIPTION
Github has phased out the use of "git:"

## Summary by Sourcery

Documentation:
- Update README installation instructions to clone the repository over HTTPS instead of the git protocol.