### PR TITLE
#69 support compile under Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,45 @@
+# Enforce Unix line endings for all files by default
+* text=auto eol=lf
+
+# Source code
+*.cpp text eol=lf
+*.cc text eol=lf
+*.h text eol=lf
+*.hpp text eol=lf
+
+# Configuration and build files
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.xml text eol=lf
+*.toml text eol=lf
+meson.build text eol=lf
+meson_options.txt text eol=lf
+
+# Documentation
+*.md text eol=lf
+*.txt text eol=lf
+*.po text eol=lf
+*.pot text eol=lf
+
+# Scripts
+*.sh text eol=lf
+*.py text eol=lf
+
+# Binary files - preserve as-is
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.bin binary
+*.o binary
+*.a binary
+*.so binary
+*.dylib binary
+
+# Test data - preserve exact bytes
+tests/testdata/** binary
+examples/testdata/** binary
+src/**/testdata/** binary
+*.dat binary

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,4 +44,7 @@ jobs:
         run: meson install -C build
 
       - name: Test
+        run: meson test -C build --verbose --no-stdsplit
+
+      - name: Check iptux version
         run: iptux --version

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
@@ -44,4 +44,4 @@ jobs:
         run: meson install -C build
 
       - name: Test
-        run: meson test -C build --verbose --no-stdsplit
+        run: iptux --version

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: read
+    env:
+      GIT_AUTOCRLF: false
     defaults:
       run:
         shell: msys2 {0}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,32 +16,32 @@ jobs:
         shell: msys2 {0}
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: CLANG64
           update: true
           install: >-
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-meson
-            mingw-w64-x86_64-ninja
-            mingw-w64-x86_64-pkg-config
-            mingw-w64-x86_64-gtk3
-            mingw-w64-x86_64-glib2
-            mingw-w64-x86_64-jsoncpp
-            mingw-w64-x86_64-libsigc++
-            mingw-w64-x86_64-gettext-tools
-            mingw-w64-x86_64-appstream
-      
+            mingw-w64-clang-x86_64-clang
+            mingw-w64-clang-x86_64-meson
+            mingw-w64-clang-x86_64-ninja
+            mingw-w64-clang-x86_64-pkg-config
+            mingw-w64-clang-x86_64-gtk3
+            mingw-w64-clang-x86_64-glib2
+            mingw-w64-clang-x86_64-jsoncpp
+            mingw-w64-clang-x86_64-libsigc++
+            mingw-w64-clang-x86_64-gettext-tools
+            mingw-w64-clang-x86_64-appstream
+
       - name: Configure
         run: meson setup build
-      
+
       - name: Build
         run: meson compile -C build
-      
+
       - name: Install
         run: meson install -C build
-      
+
       - name: Test
         run: meson test -C build --verbose --no-stdsplit

--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,9 @@ endif
 if (cc.has_argument('-Wno-c99-designator'))
   add_project_arguments('-Wno-c99-designator', language : 'cpp')
 endif
+if (cc.has_argument('-Wno-missing-field-initializers'))
+  add_project_arguments('-Wno-missing-field-initializers', language : 'cpp')
+endif
 if host_machine.system() == 'darwin'
   add_languages('objcpp')
   add_project_arguments('-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_70', language : 'objcpp')

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,13 @@ endif
 if (cc.has_argument('-Wno-missing-field-initializers'))
   add_project_arguments('-Wno-missing-field-initializers', language : 'cpp')
 endif
+if (cc.has_argument('-Wno-missing-braces'))
+  add_project_arguments('-Wno-missing-braces', language : 'cpp')
+endif
+# clang does not treat NULL as sentinel, only nullptr
+if (cc.has_argument('-Wno-sentinel'))
+  add_project_arguments('-Wno-sentinel', language : 'cpp')
+endif
 if host_machine.system() == 'darwin'
   add_languages('objcpp')
   add_project_arguments('-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_70', language : 'objcpp')

--- a/src/api/iptux-core/CoreThread.h
+++ b/src/api/iptux-core/CoreThread.h
@@ -7,7 +7,6 @@
 #include <atomic>
 #include <cstdint>
 #include <memory>
-#include <netinet/in.h>
 #include <vector>
 
 #include <sigc++/signal.h>

--- a/src/api/iptux-core/CoreThread.h
+++ b/src/api/iptux-core/CoreThread.h
@@ -77,12 +77,15 @@ class CoreThread {
   const std::vector<std::shared_ptr<PalInfo>>& GetPalList();
   virtual void ClearAllPalFromList();
 
-  CPPalInfo GetPal(PalKey palKey) const;
-  PPalInfo GetPal(PalKey palKey);
-  CPPalInfo GetPal(in_addr ipv4) const { return GetPal(PalKey(ipv4, port())); }
-  PPalInfo GetPal(in_addr ipv4) { return GetPal(PalKey(ipv4, port())); }
-  CPPalInfo GetPal(const std::string& ipv4) const;
-  PPalInfo GetPal(const std::string& ipv4);
+  PalInfo::ConstPtr GetPal(PalKey palKey) const;
+  PalInfo::Ptr GetPal(PalKey palKey);
+  PalInfo::ConstPtr GetPal(in_addr ipv4) const {
+    return GetPal(PalKey(ipv4, port()));
+  }
+  PalInfo::Ptr GetPal(in_addr ipv4) { return GetPal(PalKey(ipv4, port())); }
+  PalInfo::ConstPtr GetPal(const std::string& ipv4) const;
+  PalInfo::Ptr GetPal(const std::string& ipv4);
+  PalInfo::Ptr GetPal(GInetAddress* gaddr);
 
   virtual void DelPalFromList(PalKey palKey);
   virtual void DelPalFromList(in_addr palKey) {

--- a/src/api/iptux-core/Exception.h
+++ b/src/api/iptux-core/Exception.h
@@ -32,7 +32,7 @@ class Exception : public std::runtime_error {
             const std::string& reason,
             std::exception* causedBy);
 
-  const ErrorCode& getErrorCode() const;
+  const ErrorCode& getErrorCode() const { return ec; }
 
  private:
   const ErrorCode& ec;

--- a/src/api/iptux-core/Models.h
+++ b/src/api/iptux-core/Models.h
@@ -19,6 +19,7 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #else
+#include <netinet/in.h>
 #endif
 
 namespace iptux {

--- a/src/api/iptux-core/Models.h
+++ b/src/api/iptux-core/Models.h
@@ -16,7 +16,10 @@
 #include <string>
 
 #include <json/json.h>
-#include "iptux-core/internal/iptux_network.h"
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#endif
 
 namespace iptux {
 

--- a/src/api/iptux-core/Models.h
+++ b/src/api/iptux-core/Models.h
@@ -12,12 +12,11 @@
 #ifndef IPTUX_MODELS_H
 #define IPTUX_MODELS_H
 
-#include <arpa/inet.h>
 #include <memory>
-#include <netinet/in.h>
 #include <string>
 
 #include <json/json.h>
+#include "iptux-core/internal/iptux_network.h"
 
 namespace iptux {
 
@@ -27,7 +26,7 @@ namespace iptux {
 enum class MessageSourceType {
   PAL,   ///< 好友
   SELF,  ///< 自身
-  ERROR  ///< 错误
+  MST_ERROR  ///< 错误
 };
 
 /**

--- a/src/api/iptux-core/Models.h
+++ b/src/api/iptux-core/Models.h
@@ -82,6 +82,10 @@ class PalKey {
  */
 class PalInfo {
  public:
+  typedef std::shared_ptr<PalInfo> Ptr;
+  typedef std::shared_ptr<const PalInfo> ConstPtr;
+
+ public:
   PalInfo(const std::string& ipv4, uint16_t port);
   PalInfo(in_addr ipv4, uint16_t port);
   ~PalInfo();

--- a/src/api/iptux-core/ProgramData.h
+++ b/src/api/iptux-core/ProgramData.h
@@ -8,7 +8,6 @@
 #include "iptux-core/IptuxConfig.h"
 #include "iptux-core/Models.h"
 #include "iptux-core/StatusIconMode.h"
-#include "iptux-core/internal/iptux_network.h"
 
 namespace iptux {
 

--- a/src/api/iptux-core/ProgramData.h
+++ b/src/api/iptux-core/ProgramData.h
@@ -8,6 +8,7 @@
 #include "iptux-core/IptuxConfig.h"
 #include "iptux-core/Models.h"
 #include "iptux-core/StatusIconMode.h"
+#include "iptux-core/internal/iptux_network.h"
 
 namespace iptux {
 

--- a/src/api/iptux-core/TransFileModel.h
+++ b/src/api/iptux-core/TransFileModel.h
@@ -2,6 +2,7 @@
 #define IPTUX_TRANSFILEMODEL_H
 
 #include <string>
+#include <cstdint>
 
 namespace iptux {
 

--- a/src/iptux-core/CoreThread.cpp
+++ b/src/iptux-core/CoreThread.cpp
@@ -16,7 +16,6 @@
 
 #include <glib/gi18n.h>
 #include <glib/gstdio.h>
-#include <sys/socket.h>
 
 #include "iptux-core/internal/Command.h"
 #include "iptux-core/internal/RecvFileData.h"

--- a/src/iptux-core/CoreThread.cpp
+++ b/src/iptux-core/CoreThread.cpp
@@ -637,12 +637,25 @@ static gboolean tcpHandlerCleanupCb(gpointer data) {
 
 static gpointer tcpHandlerThreadFunc(gpointer data) {
   TcpHandlerData* handlerData = static_cast<TcpHandlerData*>(data);
+  GError* error = nullptr;
+  bool res;
+
   try {
-    TcpData::TcpDataEntry(handlerData->coreThread, handlerData->clientSocket);
+    res = TcpData::TcpDataEntry(handlerData->coreThread,
+                                handlerData->clientSocket, &error);
   } catch (const std::exception& e) {
     LOG_ERROR("Exception in TCP handler: %s", e.what());
   } catch (...) {
     LOG_ERROR("Unknown exception in TCP handler");
+  }
+
+  if (!res) {
+    if (error) {
+      LOG_ERROR("TCP handler failed: %s", error->message);
+      g_clear_error(&error);
+    } else {
+      LOG_ERROR("TCP handler failed with unknown error");
+    }
   }
 
   // Schedule cleanup on TCP thread's main context
@@ -943,6 +956,20 @@ shared_ptr<PalInfo> CoreThread::GetPal(PalKey palKey) {
     }
   }
   return {};
+}
+
+PalInfo::Ptr CoreThread::GetPal(GInetAddress* gaddr) {
+  struct in_addr addr;
+
+  if (!gaddr) {
+    return {};
+  }
+
+  if (!iptux_inet_address_to_in_addr(gaddr, &addr)) {
+    LOG_ERROR("Failed to convert GInetAddress to in_addr");
+    return {};
+  }
+  return GetPal(addr);
 }
 
 shared_ptr<PalInfo> CoreThread::GetPal(const string& ipv4) {

--- a/src/iptux-core/Models.cpp
+++ b/src/iptux-core/Models.cpp
@@ -14,7 +14,6 @@
 
 #include <glib/gi18n.h>
 #include <glib/gstdio.h>
-#include <netinet/in.h>
 #include <sstream>
 #include <unistd.h>
 

--- a/src/iptux-core/ModelsTest.cpp
+++ b/src/iptux-core/ModelsTest.cpp
@@ -31,9 +31,9 @@ TEST(NetSegment, ContainIP) {
                         "1.2.4.0", "1.2.3.5", "1.2.4.4"};
 
   for (const string& ip : ips) {
-    in_addr ip1;
+    in_addr ip1 = inAddrFromString(ip);
     ASSERT_TRUE(is_ipv4(ip.c_str())) << ip;
-    ASSERT_TRUE(netSegment.ContainIP(ip1));
+    ASSERT_TRUE(netSegment.ContainIP(ip1)) << ip;
   }
 
   vector<string> ips2 = {

--- a/src/iptux-core/ModelsTest.cpp
+++ b/src/iptux-core/ModelsTest.cpp
@@ -32,7 +32,7 @@ TEST(NetSegment, ContainIP) {
 
   for (const string& ip : ips) {
     in_addr ip1;
-    ASSERT_EQ(inet_pton(AF_INET, ip.c_str(), &ip1.s_addr), 1) << ip;
+    ASSERT_TRUE(is_ipv4(ip.c_str())) << ip;
     ASSERT_TRUE(netSegment.ContainIP(ip1));
   }
 
@@ -44,7 +44,7 @@ TEST(NetSegment, ContainIP) {
   };
   for (const string& ip : ips2) {
     in_addr ip1;
-    ASSERT_EQ(inet_pton(AF_INET, ip.c_str(), &ip1), 1) << ip;
+    ASSERT_TRUE(is_ipv4(ip.c_str())) << ip;
     ASSERT_FALSE(netSegment.ContainIP(ip1));
   }
 }

--- a/src/iptux-core/ModelsTest.cpp
+++ b/src/iptux-core/ModelsTest.cpp
@@ -43,7 +43,7 @@ TEST(NetSegment, ContainIP) {
       "100.100.100.100",
   };
   for (const string& ip : ips2) {
-    in_addr ip1;
+    in_addr ip1 = inAddrFromString(ip);
     ASSERT_TRUE(is_ipv4(ip.c_str())) << ip;
     ASSERT_FALSE(netSegment.ContainIP(ip1));
   }

--- a/src/iptux-core/ProgramData.cpp
+++ b/src/iptux-core/ProgramData.cpp
@@ -174,7 +174,7 @@ void ProgramData::ReadProgData() {
     fileInfo.fileid = pbn++;
     fileInfo.fileattr =
         S_ISREG(st.st_mode) ? FileAttr::REGULAR : FileAttr::DIRECTORY;
-    fileInfo.filepath = strdup(sharedFileList[i].c_str());
+    fileInfo.filepath = g_strdup(sharedFileList[i].c_str());
     sharedFileInfos.emplace_back(fileInfo);
   }
 }

--- a/src/iptux-core/internal/AnalogFS.cpp
+++ b/src/iptux-core/internal/AnalogFS.cpp
@@ -12,15 +12,15 @@
 #include "config.h"
 #include "AnalogFS.h"
 
-#include <cstring>
-#include <fcntl.h>
-#include <glib/gstdio.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
 #include "iptux-core/internal/ipmsg.h"
 #include "iptux-utils/output.h"
 #include "iptux-utils/utils.h"
+#include <cstring>
+#include <fcntl.h>
+#include <glib/gi18n.h>
+#include <glib/gstdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 using namespace std;
 
@@ -53,25 +53,27 @@ AnalogFS::~AnalogFS() {}
  * @return 成功与否
  */
 int AnalogFS::chdir(const char* dir) {
-  size_t len;
-  char* ptr;
+  char* new_path;
 
-  if (strcmp(dir, ".") == 0)
-    return 0;
+  if (g_path_is_absolute(dir)) {
+    new_path = g_strdup(dir);
+  } else {
+    new_path = g_build_filename(this->path, dir, NULL);
+  }
 
-  if (*dir != '/') {
-    if (strcmp(dir, "..") == 0) {
-      ptr = strrchr(path, '/');
-      if (ptr != path)
-        *ptr = '\0';
-    } else {
-      len = strlen(path);
-      ptr = (char*)(*(path + 1) != '\0' ? "/" : "");
-      snprintf(path + len, MAX_PATHLEN - len, "%s%s", ptr, dir);
-    }
-  } else
-    snprintf(path, MAX_PATHLEN, "%s", dir);
-
+  if (!new_path) {
+    LOG_WARN("Failed to build new path from \"%s\" and \"%s\"", this->path,
+             dir);
+    return -1;
+  }
+  if (strlen(new_path) >= MAX_PATHLEN) {
+    LOG_WARN("New path \"%s\" exceeds maximum length of %d", new_path,
+             MAX_PATHLEN);
+    g_free(new_path);
+    return -1;
+  }
+  strcpy(this->path, new_path);
+  g_free(new_path);
   return 0;
 }
 
@@ -121,7 +123,7 @@ int AnalogFS::stat(const char* fn, struct ::stat* st) {
   strcpy(tpath, path);
   mergepath(tpath, MAX_PATHLEN, fn);
   if ((result = ::stat(tpath, st)) != 0) {
-    pwarning(_("Stat64() file \"%s\" failed, %s"), tpath, strerror(errno));
+    LOG_WARN(_("Stat64() file \"%s\" failed, %s"), tpath, strerror(errno));
   }
 
   return result;
@@ -186,7 +188,12 @@ DIR* AnalogFS::opendir(const char* dir) {
 bool mergepath(char tpath[], int len, const char* npath) {
   gchar* full_path;
 
-  full_path = g_build_filename(tpath, npath, NULL);
+  if (g_path_is_absolute(npath)) {
+    full_path = g_strdup(npath);
+  } else {
+    full_path = g_build_filename(tpath, npath, NULL);
+  }
+
   if (!full_path) {
     return false;
   }

--- a/src/iptux-core/internal/AnalogFS.cpp
+++ b/src/iptux-core/internal/AnalogFS.cpp
@@ -26,7 +26,7 @@ using namespace std;
 
 namespace iptux {
 
-static int mergepath(char tpath[], const char* npath);
+static bool mergepath(char tpath[], int len, const char* npath);
 
 /**
  * 类构造函数.
@@ -86,7 +86,10 @@ int AnalogFS::open(const char* fn, int flags, mode_t mode) {
   int fd;
 
   strcpy(tpath, path);
-  mergepath(tpath, fn);
+  if (!mergepath(tpath, MAX_PATHLEN, fn)) {
+    LOG_WARN("Merge path failed, \"%s\" + \"%s\"", path, fn);
+    return -1;
+  }
   if ((flags & O_ACCMODE) == O_WRONLY) {
     auto tfn = assert_filename_inexist(tpath);
     if ((fd = ::open(tfn.c_str(), flags, mode)) == -1) {
@@ -112,7 +115,7 @@ int AnalogFS::stat(const char* fn, struct ::stat* st) {
   int result;
 
   strcpy(tpath, path);
-  mergepath(tpath, fn);
+  mergepath(tpath, MAX_PATHLEN, fn);
   if ((result = ::stat(tpath, st)) != 0) {
     pwarning(_("Stat64() file \"%s\" failed, %s"), tpath, strerror(errno));
   }
@@ -131,7 +134,7 @@ int AnalogFS::makeDir(const char* dir, mode_t mode) {
   int result;
 
   strcpy(tpath, path);
-  mergepath(tpath, dir);
+  mergepath(tpath, MAX_PATHLEN, dir);
   if (::access(tpath, F_OK) == 0)
     return 0;
   if ((result = g_mkdir(tpath, mode)) != 0) {
@@ -159,7 +162,10 @@ DIR* AnalogFS::opendir(const char* dir) {
   DIR* dirs;
 
   strcpy(tpath, path);
-  mergepath(tpath, dir);
+  if (!mergepath(tpath, MAX_PATHLEN, dir)) {
+    LOG_WARN("Merge path failed, \"%s\" + \"%s\"", path, dir);
+    return nullptr;
+  }
   if (!(dirs = ::opendir(tpath))) {
     pwarning(_("Opendir() directory \"%s\" failed, %s"), tpath,
              strerror(errno));
@@ -173,27 +179,22 @@ DIR* AnalogFS::opendir(const char* dir) {
  * @param npath 需要被合并的路径
  * @return 成功与否
  */
-int mergepath(char tpath[], const char* npath) {
-  size_t len;
-  char* ptr;
+bool mergepath(char tpath[], int len, const char* npath) {
+  gchar* full_path;
 
-  if (strcmp(npath, ".") == 0)
-    return 0;
+  full_path = g_build_filename(tpath, npath, NULL);
+  if (!full_path) {
+    return false;
+  }
 
-  if (*npath != '/') {
-    if (strcmp(npath, "..") == 0) {
-      ptr = strrchr(tpath, '/');
-      if (ptr != tpath)
-        *ptr = '\0';
-    } else {
-      len = strlen(tpath);
-      ptr = (char*)(*(tpath + 1) != '\0' ? "/" : "");
-      snprintf(tpath + len, MAX_PATHLEN - len, "%s%s", ptr, npath);
-    }
-  } else
-    snprintf(tpath, MAX_PATHLEN, "%s", npath);
+  if ((int)strlen(full_path) >= len) {
+    g_free(full_path);
+    return false;
+  }
 
-  return 0;
+  strcpy(tpath, full_path);
+  g_free(full_path);
+  return true;
 }
 
 }  // namespace iptux

--- a/src/iptux-core/internal/AnalogFS.cpp
+++ b/src/iptux-core/internal/AnalogFS.cpp
@@ -35,6 +35,7 @@ AnalogFS::AnalogFS() {
   if (!::getcwd(path, MAX_PATHLEN)) {
     strcpy(path, "/");
   }
+  LOG_INFO("AnalogFS initialized, cwd: %s", path);
 }
 
 /**

--- a/src/iptux-core/internal/AnalogFS.cpp
+++ b/src/iptux-core/internal/AnalogFS.cpp
@@ -32,7 +32,11 @@ static bool mergepath(char tpath[], int len, const char* npath);
  * 类构造函数.
  */
 AnalogFS::AnalogFS() {
-  if (!::getcwd(path, MAX_PATHLEN)) {
+  gchar* current_dir = g_get_current_dir();
+  if (current_dir) {
+    strncpy(path, current_dir, MAX_PATHLEN);
+    g_free(current_dir);
+  } else {
     strcpy(path, "/");
   }
   LOG_INFO("AnalogFS initialized, cwd: %s", path);

--- a/src/iptux-core/internal/AnalogFS.cpp
+++ b/src/iptux-core/internal/AnalogFS.cpp
@@ -34,7 +34,7 @@ static bool mergepath(char tpath[], int len, const char* npath);
 AnalogFS::AnalogFS() {
   gchar* current_dir = g_get_current_dir();
   if (current_dir) {
-    strncpy(path, current_dir, MAX_PATHLEN);
+    g_strlcpy(path, current_dir, MAX_PATHLEN);
     g_free(current_dir);
   } else {
     strcpy(path, "/");

--- a/src/iptux-core/internal/AnalogFS.cpp
+++ b/src/iptux-core/internal/AnalogFS.cpp
@@ -98,12 +98,11 @@ int AnalogFS::open(const char* fn, int flags, mode_t mode) {
   if ((flags & O_ACCMODE) == O_WRONLY) {
     auto tfn = assert_filename_inexist(tpath);
     if ((fd = ::open(tfn.c_str(), flags, mode)) == -1) {
-      pwarning(_("Open() file \"%s\" failed, %s"), tfn.c_str(),
-               strerror(errno));
+      LOG_WARN("Open() file \"%s\" failed, %s", tfn.c_str(), strerror(errno));
     }
   } else {
     if ((fd = ::open(tpath, flags, mode)) == -1) {
-      pwarning(_("Open() file \"%s\" failed, %s"), tpath, strerror(errno));
+      LOG_WARN("Open() file \"%s\" failed, %s", tpath, strerror(errno));
     }
   }
   return fd;

--- a/src/iptux-core/internal/Command.cpp
+++ b/src/iptux-core/internal/Command.cpp
@@ -14,7 +14,6 @@
 
 #include <cinttypes>
 #include <fcntl.h>
-#include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -74,7 +73,7 @@ static bool commandSendTo(int sockfd,
   addr.sin_family = AF_INET;
   addr.sin_port = htons(port);
   addr.sin_addr = ipv4;
-  return sendto(sockfd, buf, len, flags, (struct sockaddr*)(&addr),
+  return sendto(sockfd, (const char*)buf, len, flags, (struct sockaddr*)(&addr),
                 sizeof(struct sockaddr_in)) != -1;
 }
 
@@ -484,7 +483,7 @@ void Command::FeedbackError(CPPalInfo pal,
                             GroupBelongType btype,
                             const char* error) {
   MsgPara para(coreThread.GetPal(pal->GetKey()));
-  para.stype = MessageSourceType::ERROR;
+  para.stype = MessageSourceType::MST_ERROR;
   para.btype = btype;
 
   ChipData chip(MESSAGE_CONTENT_TYPE_STRING, error);

--- a/src/iptux-core/internal/Command.cpp
+++ b/src/iptux-core/internal/Command.cpp
@@ -733,8 +733,7 @@ vector<FileInfo> Command::decodeFileInfos(const string& s) {
 }
 
 string Command::encodeFileInfo(const FileInfo& fileInfo) {
-  auto name =
-      ipmsg_get_filename_pal(fileInfo.filepath);  // 获取面向好友的文件名
+  auto name = g_path_get_basename(fileInfo.filepath);
   auto res = stringFormat(
       "%" PRIu32 ":%s:%" PRIx64 ":%" PRIx32 ":%x:\a:", fileInfo.fileid, name,
       fileInfo.filesize, fileInfo.filectime, (unsigned int)fileInfo.fileattr);

--- a/src/iptux-core/internal/Command.cpp
+++ b/src/iptux-core/internal/Command.cpp
@@ -21,10 +21,13 @@
 
 #include "iptux-core/Exception.h"
 #include "iptux-core/Models.h"
-#include "iptux-core/internal/TransAbstract.h"
 #include "iptux-core/internal/support.h"
 #include "iptux-utils/output.h"
 #include "iptux-utils/utils.h"
+
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
 
 using namespace std;
 
@@ -533,7 +536,7 @@ bool Command::SendSublayer(GSocket* sock,
     return false;
   }
 
-  if ((fd = open(path, O_RDONLY)) == -1) {
+  if ((fd = open(path, O_RDONLY | O_BINARY)) == -1) {
     LOG_WARN("open file failed: %s", path);
     return false;
   }

--- a/src/iptux-core/internal/RecvFileData.cpp
+++ b/src/iptux-core/internal/RecvFileData.cpp
@@ -12,6 +12,7 @@
 #include "config.h"
 #include "RecvFileData.h"
 
+#include "gio/gio.h"
 #include <memory>
 
 #include <fcntl.h>
@@ -140,16 +141,10 @@ void RecvFileData::RecvRegularFile() {
   AnalogFS afs;
   Command cmd(*coreThread);
   int64_t finishsize;
-  int fd;
   struct utimbuf timebuf;
-  mode_t mode;
-
-#if defined(_WIN32) || defined(_WIN64)
-  mode = S_IREAD | S_IWRITE;
-#else
-  mode = 0644;
-#endif
-
+  string fullpath;
+  GFile* gfile = NULL;
+  GFileOutputStream* fos = NULL;
   GError* error = nullptr;
   GSocket* sock = g_socket_new(G_SOCKET_FAMILY_IPV4, G_SOCKET_TYPE_STREAM,
                                G_SOCKET_PROTOCOL_TCP, &error);
@@ -168,18 +163,27 @@ void RecvFileData::RecvRegularFile() {
     return;
   }
 
-  if ((fd = afs.open(file->filepath,
-                     O_WRONLY | O_CREAT | O_TRUNC | O_LARGEFILE | O_BINARY,
-                     mode)) == -1) {
-    LOG_WARN("Failed to open file \"%s\" for writing", file->filepath);
-    g_object_unref(sock);
-    terminate = true;
-    return;
+  fullpath = assert_filename_inexist(file->filepath);
+  if (fullpath.empty()) {
+    LOG_ERROR("Failed to get full path for writing: %s", file->filepath);
+    goto fail;
+  }
+
+  gfile = g_file_new_for_path(fullpath.c_str());
+  if (!gfile) {
+    LOG_ERROR("Failed to create GFile for path: %s", fullpath.c_str());
+    goto fail;
+  }
+
+  fos = g_file_replace(gfile, NULL, FALSE, G_FILE_CREATE_NONE, NULL, &error);
+  if (!fos) {
+    LOG_ERROR("Failed to create GFileOutputStream for path: %s, error: %s",
+              fullpath.c_str(), error->message);
+    goto fail;
   }
 
   gettimeofday(&filetime, NULL);
-  finishsize = RecvData(sock, fd, file->filesize, 0);
-  close(fd);
+  finishsize = RecvData(sock, G_OUTPUT_STREAM(fos), file->filesize, 0);
   if (file->filectime != 0) {
     timebuf.actime = int(file->filectime);
     timebuf.modtime = int(file->filectime);
@@ -196,8 +200,22 @@ void RecvFileData::RecvRegularFile() {
     LOG_INFO(_("Receive the file \"%s\" from %s successfully!"), file->filepath,
              file->fileown->getName().c_str());
   }
-
+  g_object_unref(fos);
+  g_object_unref(gfile);
   g_object_unref(sock);
+  return;
+fail:
+  if (error) {
+    g_error_free(error);
+  }
+  if (fos)
+    g_object_unref(fos);
+  if (gfile)
+    g_object_unref(gfile);
+  if (sock)
+    g_object_unref(sock);
+  this->terminate = true;
+  return;
 }
 
 /**
@@ -438,6 +456,66 @@ int64_t RecvFileData::RecvData(GSocket* sock,
     }
     if (size > 0 && xwrite(fd, buf, size) == -1)
       return finishsize;
+    finishsize += size;
+    sumsize += size;
+    file->finishedsize = sumsize;
+
+    gettimeofday(&val2, NULL);
+    difftime = difftimeval(val2, val1);
+    if (difftime >= 1) {
+      rate = (uint32_t)((finishsize - tmpsize) / difftime);
+      para.setFinishedLength(finishsize)
+          .setCost(numeric_to_time((uint32_t)(difftimeval(val2, filetime))))
+          .setRemain(
+              numeric_to_time((uint32_t)((filesize - finishsize) / rate)))
+          .setRate(numeric_to_rate(rate));
+      val1 = val2;
+      tmpsize = finishsize;
+    }
+  } while (!terminate && size && finishsize < filesize);
+
+  return finishsize;
+}
+
+int64_t RecvFileData::RecvData(GSocket* sock,
+                               GOutputStream* os,
+                               int64_t filesize,
+                               int64_t offset) {
+  int64_t tmpsize, finishsize;
+  struct timeval val1, val2;
+  float difftime;
+  uint32_t rate;
+  gssize size;
+
+  if (offset == filesize)
+    return filesize;
+
+  tmpsize = finishsize = offset;
+  gettimeofday(&val1, NULL);
+  do {
+    size = MAX_SOCKLEN < filesize - finishsize ? MAX_SOCKLEN
+                                               : filesize - finishsize;
+    GError* error = nullptr;
+    size = g_socket_receive(sock, buf, size, nullptr, &error);
+    if (size == -1) {
+      if (error) {
+        LOG_WARN("g_socket_receive failed: %s", error->message);
+        g_error_free(error);
+      }
+      return finishsize;
+    }
+
+    if (size == 0) {
+      return finishsize;
+    }
+
+    gsize bytes_written = 0;
+    if (g_output_stream_write_all(os, buf, size, &bytes_written, nullptr,
+                                  &error) == -1) {
+      LOG_WARN("g_output_stream_write_all failed: %s", error->message);
+      g_error_free(error);
+      return finishsize + bytes_written;
+    }
     finishsize += size;
     sumsize += size;
     file->finishedsize = sumsize;

--- a/src/iptux-core/internal/RecvFileData.cpp
+++ b/src/iptux-core/internal/RecvFileData.cpp
@@ -200,6 +200,11 @@ void RecvFileData::RecvRegularFile() {
     LOG_INFO(_("Receive the file \"%s\" from %s successfully!"), file->filepath,
              file->fileown->getName().c_str());
   }
+  if (!g_output_stream_close(G_OUTPUT_STREAM(fos), NULL, &error)) {
+    LOG_ERROR("Failed to close GFileOutputStream for path: %s, error: %s",
+              fullpath.c_str(), error->message);
+    goto fail;
+  }
   g_object_unref(fos);
   g_object_unref(gfile);
   g_object_unref(sock);

--- a/src/iptux-core/internal/RecvFileData.cpp
+++ b/src/iptux-core/internal/RecvFileData.cpp
@@ -33,6 +33,10 @@
 #define O_LARGEFILE 0
 #endif
 
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
 using namespace std;
 
 namespace iptux {
@@ -138,6 +142,13 @@ void RecvFileData::RecvRegularFile() {
   int64_t finishsize;
   int fd;
   struct utimbuf timebuf;
+  mode_t mode;
+
+#if defined(_WIN32) || defined(_WIN64)
+  mode = S_IREAD | S_IWRITE;
+#else
+  mode = 0644;
+#endif
 
   GError* error = nullptr;
   GSocket* sock = g_socket_new(G_SOCKET_FAMILY_IPV4, G_SOCKET_TYPE_STREAM,
@@ -157,8 +168,9 @@ void RecvFileData::RecvRegularFile() {
     return;
   }
 
-  if ((fd = afs.open(file->filepath, O_WRONLY | O_CREAT | O_TRUNC | O_LARGEFILE,
-                     00644)) == -1) {
+  if ((fd = afs.open(file->filepath,
+                     O_WRONLY | O_CREAT | O_TRUNC | O_LARGEFILE | O_BINARY,
+                     mode)) == -1) {
     LOG_WARN("Failed to open file \"%s\" for writing", file->filepath);
     g_object_unref(sock);
     terminate = true;

--- a/src/iptux-core/internal/RecvFileData.cpp
+++ b/src/iptux-core/internal/RecvFileData.cpp
@@ -118,7 +118,7 @@ void RecvFileData::CreateUIPara() {
   para.setStatus("tip-recv")
       .setTask(_("receive"))
       .setPeer(file->fileown->getName())
-      .setIp(inet_ntoa(addr))
+      .setIp(inAddrToString(addr))
       .setFilename(ipmsg_get_filename_me(file->filepath, NULL))
       .setFileLength(file->filesize)
       .setFinishedLength(0)

--- a/src/iptux-core/internal/RecvFileData.cpp
+++ b/src/iptux-core/internal/RecvFileData.cpp
@@ -151,6 +151,7 @@ void RecvFileData::RecvRegularFile() {
 
   if (!cmd.SendAskData(sock, file->fileown->GetKey(), file->packetn,
                        file->fileid, 0)) {
+    LOG_WARN("Failed to send ask data command");
     g_object_unref(sock);
     terminate = true;
     return;
@@ -158,6 +159,7 @@ void RecvFileData::RecvRegularFile() {
 
   if ((fd = afs.open(file->filepath, O_WRONLY | O_CREAT | O_TRUNC | O_LARGEFILE,
                      00644)) == -1) {
+    LOG_WARN("Failed to open file \"%s\" for writing", file->filepath);
     g_object_unref(sock);
     terminate = true;
     return;

--- a/src/iptux-core/internal/RecvFileData.cpp
+++ b/src/iptux-core/internal/RecvFileData.cpp
@@ -370,61 +370,6 @@ end:
 }
 
 /**
- * 接收文件数据.
- * @param sock tcp socket
- * @param fd file descriptor
- * @param filesize 文件总长度
- * @param offset 已读取数据量
- * @return 完成数据量
- */
-int64_t RecvFileData::RecvData(int sock,
-                               int fd,
-                               int64_t filesize,
-                               int64_t offset) {
-  int64_t tmpsize, finishsize;
-  struct timeval val1, val2;
-  float difftime;
-  uint32_t rate;
-  ssize_t size;
-
-  /* 如果文件数据已经完全被接收，则直接返回 */
-  if (offset == filesize)
-    return filesize;
-
-  /* 接收数据 */
-  tmpsize = finishsize = offset;  // 初始化已读取数据量
-  gettimeofday(&val1, NULL);      // 初始化起始时间
-  do {
-    /* 接收数据并写入磁盘 */
-    size = MAX_SOCKLEN < filesize - finishsize ? MAX_SOCKLEN
-                                               : filesize - finishsize;
-    if ((size = xread(sock, buf, size)) == -1)
-      return finishsize;
-    if (size > 0 && xwrite(fd, buf, size) == -1)
-      return finishsize;
-    finishsize += size;
-    sumsize += size;
-    file->finishedsize = sumsize;
-    /* 判断是否需要更新UI参考值 */
-    gettimeofday(&val2, NULL);
-    difftime = difftimeval(val2, val1);
-    if (difftime >= 1) {
-      /* 更新UI参考值 */
-      rate = (uint32_t)((finishsize - tmpsize) / difftime);
-      para.setFinishedLength(finishsize)
-          .setCost(numeric_to_time((uint32_t)(difftimeval(val2, filetime))))
-          .setRemain(
-              numeric_to_time((uint32_t)((filesize - finishsize) / rate)))
-          .setRate(numeric_to_rate(rate));
-      val1 = val2;           // 更新时间参考点
-      tmpsize = finishsize;  // 更新下载量
-    }
-  } while (!terminate && size && finishsize < filesize);
-
-  return finishsize;
-}
-
-/**
  * Receive file data from network socket.
  * @param sock GSocket tcp socket
  * @param fd file descriptor

--- a/src/iptux-core/internal/RecvFileData.cpp
+++ b/src/iptux-core/internal/RecvFileData.cpp
@@ -15,7 +15,6 @@
 #include <memory>
 
 #include <fcntl.h>
-#include <sys/socket.h>
 #include <sys/time.h>
 #include <unistd.h>
 #include <utime.h>
@@ -29,6 +28,10 @@
 #include "iptux-core/internal/ipmsg.h"
 #include "iptux-utils/output.h"
 #include "iptux-utils/utils.h"
+
+#ifndef O_LARGEFILE
+#define O_LARGEFILE 0
+#endif
 
 using namespace std;
 

--- a/src/iptux-core/internal/RecvFileData.h
+++ b/src/iptux-core/internal/RecvFileData.h
@@ -35,7 +35,6 @@ class RecvFileData : public TransAbstract {
   void RecvRegularFile();
   void RecvDirFiles();
 
-  int64_t RecvData(int sock, int fd, int64_t filesize, int64_t offset);
   int64_t RecvData(GSocket* sock,
                    GOutputStream* os,
                    int64_t filesize,

--- a/src/iptux-core/internal/RecvFileData.h
+++ b/src/iptux-core/internal/RecvFileData.h
@@ -36,6 +36,10 @@ class RecvFileData : public TransAbstract {
   void RecvDirFiles();
 
   int64_t RecvData(int sock, int fd, int64_t filesize, int64_t offset);
+  int64_t RecvData(GSocket* sock,
+                   GOutputStream* os,
+                   int64_t filesize,
+                   int64_t offset);
   int64_t RecvData(GSocket* sock, int fd, int64_t filesize, int64_t offset);
   void UpdateUIParaToOver();
 

--- a/src/iptux-core/internal/SendFile.cpp
+++ b/src/iptux-core/internal/SendFile.cpp
@@ -65,7 +65,7 @@ void SendFile::RequestDataEntry(CoreThread* coreThread,
                                 FileAttr fileattr,
                                 char* attach) {
   struct sockaddr_in addr;
-  int len;
+  socklen_t len;
   uint32_t fileid;
   uint32_t filectime;
   /* 检查文件属性是否匹配 */

--- a/src/iptux-core/internal/SendFile.cpp
+++ b/src/iptux-core/internal/SendFile.cpp
@@ -125,7 +125,7 @@ void SendFile::SendFileInfo(PPalInfo pal,
       continue;
     }
     fileInfo.ensureFilesizeFilled();
-    name = ipmsg_get_filename_pal(file->filepath);  //获取面向好友的文件名
+    name = g_path_get_basename(file->filepath);
     file->packetn = cmd.Packetn();
     snprintf(ptr, MAX_UDPLEN - len,
              "%" PRIu32 ":%s:%" PRIx64 ":%" PRIx32 ":%x:\a", file->fileid, name,

--- a/src/iptux-core/internal/SendFile.cpp
+++ b/src/iptux-core/internal/SendFile.cpp
@@ -15,13 +15,13 @@
 #include <cinttypes>
 #include <cstring>
 #include <memory>
-#include <sys/socket.h>
 #include <unistd.h>
 
 #include "iptux-core/internal/Command.h"
 #include "iptux-core/internal/SendFileData.h"
 #include "iptux-utils/output.h"
 #include "iptux-utils/utils.h"
+#include "iptux-core/internal/iptux_network.h"
 
 using namespace std;
 
@@ -65,7 +65,7 @@ void SendFile::RequestDataEntry(CoreThread* coreThread,
                                 FileAttr fileattr,
                                 char* attach) {
   struct sockaddr_in addr;
-  socklen_t len;
+  int len;
   uint32_t fileid;
   uint32_t filectime;
   /* 检查文件属性是否匹配 */

--- a/src/iptux-core/internal/SendFile.cpp
+++ b/src/iptux-core/internal/SendFile.cpp
@@ -61,7 +61,7 @@ void SendFile::BcstFileInfoEntry(CoreThread* coreThread,
  * @param attach 附加数据
  */
 void SendFile::RequestDataEntry(CoreThread* coreThread,
-                                int sock,
+                                GSocket* sock,
                                 FileAttr fileattr,
                                 char* attach) {
   struct sockaddr_in addr;
@@ -87,11 +87,14 @@ void SendFile::RequestDataEntry(CoreThread* coreThread,
     return;
   /* 检查好友数据是否存在 */
   len = sizeof(addr);
+  (void)len;
+#if 0
   getpeername(sock, (struct sockaddr*)&addr, &len);
   if (!(coreThread->GetPal(addr.sin_addr))) {
     LOG_INFO("Pal not exist: %s", inAddrToString(addr.sin_addr).c_str());
     return;
   }
+#endif
   if (!file->fileown) {
     // for public shared file, there need one owner
     file->fileown = coreThread->getMe();
@@ -180,7 +183,7 @@ void SendFile::BcstFileInfo(const std::vector<const PalInfo*>& pals,
  * @param sock tcp socket
  * @param file 文件信息
  */
-void SendFile::ThreadSendFile(int sock, PFileInfo file) {
+void SendFile::ThreadSendFile(GSocket* sock, PFileInfo file) {
   auto sfdt = make_shared<SendFileData>(coreThread, sock, file);
   coreThread->RegisterTransTask(sfdt);
   sfdt->SendFileDataEntry();

--- a/src/iptux-core/internal/SendFile.cpp
+++ b/src/iptux-core/internal/SendFile.cpp
@@ -64,8 +64,6 @@ void SendFile::RequestDataEntry(CoreThread* coreThread,
                                 GSocket* sock,
                                 FileAttr fileattr,
                                 char* attach) {
-  struct sockaddr_in addr;
-  socklen_t len;
   uint32_t fileid;
   uint32_t filectime;
   /* 检查文件属性是否匹配 */
@@ -77,7 +75,7 @@ void SendFile::RequestDataEntry(CoreThread* coreThread,
     fileid = iptux_get_dec_number(attach, ':', 1);
     file = coreThread->GetPrivateFileById(fileid);
   }
-  /* 兼容adroid版信鸽(IPMSG) */
+  /* 兼容android版信鸽(IPMSG) */
   if (!file) {
     fileid = iptux_get_hex_number(attach, ':', 0);
     filectime = iptux_get_dec_number(attach, ':', 1);
@@ -85,16 +83,6 @@ void SendFile::RequestDataEntry(CoreThread* coreThread,
   }
   if (!file || file->fileattr != fileattr)
     return;
-  /* 检查好友数据是否存在 */
-  len = sizeof(addr);
-  (void)len;
-#if 0
-  getpeername(sock, (struct sockaddr*)&addr, &len);
-  if (!(coreThread->GetPal(addr.sin_addr))) {
-    LOG_INFO("Pal not exist: %s", inAddrToString(addr.sin_addr).c_str());
-    return;
-  }
-#endif
   if (!file->fileown) {
     // for public shared file, there need one owner
     file->fileown = coreThread->getMe();

--- a/src/iptux-core/internal/SendFile.h
+++ b/src/iptux-core/internal/SendFile.h
@@ -30,7 +30,7 @@ class SendFile {
                                 const std::vector<const PalInfo*>& pals,
                                 const std::vector<FileInfo*>& files);
   static void RequestDataEntry(CoreThread* coreThread,
-                               int sock,
+                               GSocket* sock,
                                FileAttr fileattr,
                                char* attach);
 
@@ -41,7 +41,7 @@ class SendFile {
   void BcstFileInfo(const std::vector<const PalInfo*>& pals,
                     uint32_t opttype,
                     const std::vector<FileInfo*>& files);
-  void ThreadSendFile(int sock, PFileInfo file);
+  void ThreadSendFile(GSocket* sock, PFileInfo file);
 
  private:
   CoreThread* coreThread;

--- a/src/iptux-core/internal/SendFileData.cpp
+++ b/src/iptux-core/internal/SendFileData.cpp
@@ -100,7 +100,7 @@ void SendFileData::CreateUIPara() {
   para.setStatus("tip-send")
       .setTask(_("send"))
       .setPeer(file->fileown->getName())
-      .setIp(inet_ntoa(addr))
+      .setIp(inAddrToString(addr))
       .setFilename(ipmsg_get_filename_me(file->filepath, NULL))
       .setFileLength(file->filesize)
       .setFinishedLength(0)

--- a/src/iptux-core/internal/SendFileData.cpp
+++ b/src/iptux-core/internal/SendFileData.cpp
@@ -119,7 +119,7 @@ void SendFileData::SendRegularFile() {
   int fd;
 
   /* 打开文件 */
-  if ((fd = open(file->filepath, O_RDONLY | O_LARGEFILE)) == -1) {
+  if ((fd = open(file->filepath, O_RDONLY | O_LARGEFILE | O_BINARY)) == -1) {
     terminate = true;  // 标记处理过程失败
     return;
   }
@@ -135,7 +135,7 @@ void SendFileData::SendRegularFile() {
   /* 考察处理结果 */
   if (finishsize < file->filesize) {
     terminate = true;
-    LOG_INFO(_("Failed to send the file \"%s\" to %s!"), file->filepath,
+    LOG_WARN(_("Failed to send the file \"%s\" to %s!"), file->filepath,
              file->fileown->getName().c_str());
     // g_cthrd->SystemLog(_("Failed to send the file \"%s\" to %s!"),
     //                    file->filepath, file->fileown->name);
@@ -305,10 +305,20 @@ int64_t SendFileData::SendData(int fd, int64_t filesize) {
     /* 读取文件数据并发送 */
     size = MAX_SOCKLEN < filesize - finishsize ? MAX_SOCKLEN
                                                : filesize - finishsize;
-    if ((size = xread(fd, buf, MAX_SOCKLEN)) == -1)
+    if ((size = xread(fd, buf, MAX_SOCKLEN)) == -1) {
+      LOG_WARN("Failed to read file data from %s: %s", file->filepath,
+               strerror(errno));
       return finishsize;
-    if (size > 0 && xwrite(this->socket, buf, size) == -1)
+    }
+    if (size == 0) {
+      LOG_WARN("Unexpected end of file while reading from %s", file->filepath);
       return finishsize;
+    }
+    if (xwrite(this->socket, buf, size) == -1) {
+      LOG_WARN("Failed to write file data to %s: %s", file->filepath,
+               strerror(errno));
+      return finishsize;
+    }
     finishsize += size;
     sumsize += size;
     file->finishedsize = sumsize;

--- a/src/iptux-core/internal/SendFileData.cpp
+++ b/src/iptux-core/internal/SendFileData.cpp
@@ -36,13 +36,14 @@ using namespace std;
 
 namespace iptux {
 
-/**
- * 类构造函数.
- * @param sk tcp socket
- * @param fl 文件信息数据
- */
-SendFileData::SendFileData(CoreThread* coreThread, int sk, PFileInfo fl)
-    : coreThread(coreThread), sock(sk), file(fl), terminate(false), sumsize(0) {
+SendFileData::SendFileData(CoreThread* coreThread,
+                           GSocket* socket,
+                           PFileInfo fl)
+    : coreThread(coreThread),
+      socket(socket),
+      file(fl),
+      terminate(false),
+      sumsize(0) {
   buf[0] = '\0';
   gettimeofday(&tasktime, NULL);
 }
@@ -217,7 +218,7 @@ void SendFileData::SendDirFiles() {
       headsize = strlen(buf);
       snprintf(buf, MAX_SOCKLEN, "%.4" PRIx32, headsize);
       *(buf + 4) = ':';
-      if (xwrite(sock, buf, headsize) == -1)
+      if (xwrite(this->socket, buf, headsize) == -1)
         goto end;
       /* 选择处理方案 */
       gettimeofday(&filetime, NULL);
@@ -252,7 +253,7 @@ void SendFileData::SendDirFiles() {
       headsize = strlen(buf);
       snprintf(buf, MAX_SOCKLEN, "%.4" PRIx32, headsize);
       *(buf + 4) = ':';
-      if (xwrite(sock, buf, headsize) == -1)
+      if (xwrite(this->socket, buf, headsize) == -1)
         goto end;
       /* 本地端也须向上转一层 */
       afs.chdir("..");
@@ -306,7 +307,7 @@ int64_t SendFileData::SendData(int fd, int64_t filesize) {
                                                : filesize - finishsize;
     if ((size = xread(fd, buf, MAX_SOCKLEN)) == -1)
       return finishsize;
-    if (size > 0 && xwrite(sock, buf, size) == -1)
+    if (size > 0 && xwrite(this->socket, buf, size) == -1)
       return finishsize;
     finishsize += size;
     sumsize += size;

--- a/src/iptux-core/internal/SendFileData.cpp
+++ b/src/iptux-core/internal/SendFileData.cpp
@@ -234,7 +234,8 @@ void SendFileData::SendDirFiles() {
       /* 选择处理方案 */
       gettimeofday(&filetime, NULL);
       if (S_ISREG(st.st_mode)) {  // 常规文件
-        if ((fd = afs.open(dirt->d_name, O_RDONLY | O_LARGEFILE)) == -1)
+        if ((fd = afs.open(dirt->d_name, O_RDONLY | O_LARGEFILE | O_BINARY)) ==
+            -1)
           goto end;
         finishsize = SendData(fd, st.st_size);
         close(fd);

--- a/src/iptux-core/internal/SendFileData.cpp
+++ b/src/iptux-core/internal/SendFileData.cpp
@@ -15,10 +15,7 @@
 #include <cinttypes>
 #include <memory>
 
-#include <arpa/inet.h>
 #include <fcntl.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -30,6 +27,10 @@
 #include "iptux-core/Event.h"
 #include "iptux-utils/output.h"
 #include "iptux-utils/utils.h"
+
+#ifndef O_LARGEFILE
+#define O_LARGEFILE 0
+#endif
 
 using namespace std;
 

--- a/src/iptux-core/internal/SendFileData.cpp
+++ b/src/iptux-core/internal/SendFileData.cpp
@@ -203,10 +203,10 @@ void SendFileData::SendDirFiles() {
       if (strcasecmp(file->fileown->getEncode().c_str(), "utf-8") != 0 &&
           (filename = convert_encode(
                dirt->d_name, file->fileown->getEncode().c_str(), "utf-8"))) {
-        dirname = ipmsg_get_filename_pal(filename);
+        dirname = g_path_get_basename(filename);
         g_free(filename);
       } else
-        dirname = ipmsg_get_filename_pal(dirt->d_name);
+        dirname = g_path_get_basename(dirt->d_name);
       /* 构造数据头并发送 */
       snprintf(buf, MAX_SOCKLEN, "0000:%s:%.9jx:%lx:%lx=%jx:%lx=%jx:", dirname,
                (uintmax_t)(S_ISREG(st.st_mode) ? st.st_size : 0),

--- a/src/iptux-core/internal/SendFileData.cpp
+++ b/src/iptux-core/internal/SendFileData.cpp
@@ -194,9 +194,16 @@ void SendFileData::SendDirFiles() {
 
       /* 检查文件是否可用 */
     start:
-      if (afs.stat(dirt->d_name, &st) == -1 ||
-          !(S_ISREG(st.st_mode) || S_ISDIR(st.st_mode)))
+      if (afs.stat(dirt->d_name, &st) == -1) {
+        LOG_WARN("stat failed for %s: %s", dirt->d_name, strerror(errno));
         continue;
+      }
+
+      if (!(S_ISREG(st.st_mode) || S_ISDIR(st.st_mode))) {
+        LOG_INFO("Skipping unsupported file type: %s, mode: %o", dirt->d_name,
+                 st.st_mode);
+        continue;
+      }
       /* 更新UI参考值 */
       para.setFilename(dirt->d_name)
           .setFileLength(st.st_size)

--- a/src/iptux-core/internal/SendFileData.cpp
+++ b/src/iptux-core/internal/SendFileData.cpp
@@ -32,6 +32,10 @@
 #define O_LARGEFILE 0
 #endif
 
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
 using namespace std;
 
 namespace iptux {

--- a/src/iptux-core/internal/SendFileData.h
+++ b/src/iptux-core/internal/SendFileData.h
@@ -21,7 +21,7 @@ namespace iptux {
 
 class SendFileData : public TransAbstract {
  public:
-  SendFileData(CoreThread* coreThread, int sk, PFileInfo fl);
+  SendFileData(CoreThread* coreThread, GSocket* socket, PFileInfo fl);
   ~SendFileData();
 
   void SendFileDataEntry();
@@ -37,7 +37,7 @@ class SendFileData : public TransAbstract {
   void UpdateUIParaToOver();
 
   CoreThread* coreThread;
-  int sock;        //数据套接口
+  GSocket* socket;
   PFileInfo file;  //文件信息
   TransFileModel para;
   bool terminate;                     //终止标志(也作处理结果标识)

--- a/src/iptux-core/internal/TcpData.cpp
+++ b/src/iptux-core/internal/TcpData.cpp
@@ -188,7 +188,7 @@ void TcpData::RecvSublayer(uint32_t cmdopt) {
            inAddrToString(pal->ipv4()).c_str(), path);
 
   /* 终于可以接收数据了^_^ */
-  if ((fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644)) == -1) {
+  if ((fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0644)) == -1) {
     LOG_ERROR("open file %s failed: %s", path, strerror(errno));
     return;
   }

--- a/src/iptux-core/internal/TcpData.cpp
+++ b/src/iptux-core/internal/TcpData.cpp
@@ -20,6 +20,7 @@
 #include "iptux-core/internal/SendFile.h"
 #include "iptux-utils/output.h"
 #include "iptux-utils/utils.h"
+#include "iptux_error.h"
 
 #ifndef O_BINARY
 #define O_BINARY 0
@@ -48,36 +49,51 @@ TcpData::~TcpData() {
  * TCP连接处理入口.
  * @param socket GSocket for the connection (takes ownership)
  */
-void TcpData::TcpDataEntry(CoreThread* coreThread, GSocket* socket) {
+bool TcpData::TcpDataEntry(CoreThread* coreThread,
+                           GSocket* socket,
+                           GError** error) {
   TcpData tdata;
 
   tdata.coreThread = coreThread;
   tdata.socket = socket;
   tdata.sock = g_socket_get_fd(socket);
-  tdata.DispatchTcpData();
+  return tdata.DispatchTcpData(error);
 }
 
 /**
  * 分派TCP数据处理方案.
  */
-void TcpData::DispatchTcpData() {
-  GError* error = nullptr;
-  GSocketAddress* remoteAddr = g_socket_get_remote_address(socket, &error);
+bool TcpData::DispatchTcpData(GError** error) {
+  g_autoptr(GSocketAddress) remoteAddr =
+      g_socket_get_remote_address(socket, error);
+  GInetSocketAddress* inetAddr = nullptr;
+  g_autofree char* addrStr = nullptr;
+  GInetAddress* gaddr;
+  guint16 port;
+
   if (!remoteAddr) {
-    LOG_WARN("Failed to get remote address: %s",
-             error ? error->message : "unknown");
-    if (error)
-      g_error_free(error);
-    return;
+    return false;
   }
 
-  GInetSocketAddress* inetAddr = G_INET_SOCKET_ADDRESS(remoteAddr);
-  GInetAddress* gaddr = g_inet_socket_address_get_address(inetAddr);
-  guint16 port = g_inet_socket_address_get_port(inetAddr);
-  char* addrStr = g_inet_address_to_string(gaddr);
+  if (!G_IS_INET_SOCKET_ADDRESS(remoteAddr)) {
+    g_set_error_literal(error, IPTUX_CORE_ERROR, IPTUX_CORE_ERROR_SOCKET,
+                        "Remote address is not an IPv4 address");
+    return false;
+  }
+
+  inetAddr = G_INET_SOCKET_ADDRESS(remoteAddr);
+
+  gaddr = g_inet_socket_address_get_address(inetAddr);
+  port = g_inet_socket_address_get_port(inetAddr);
+  addrStr = g_inet_address_to_string(gaddr);
   LOG_DEBUG("received tcp message from %s:%d", addrStr, int(port));
-  g_object_unref(remoteAddr);
-  remoteAddr = nullptr;
+
+  if (!this->coreThread->GetPal(gaddr)) {
+    LOG_WARN("Pal not exist: %s", addrStr);
+    g_set_error(error, IPTUX_CORE_ERROR, IPTUX_CORE_ERROR_UNKNOWN_PEER,
+                "Pal not exist: %s", addrStr);
+    return false;
+  }
 
   uint32_t commandno;
   ssize_t len;
@@ -85,8 +101,9 @@ void TcpData::DispatchTcpData() {
   /* 读取消息前缀 */
   if ((len = read_ipmsg_prefix(this->socket, buf, MAX_SOCKLEN)) <= 0) {
     LOG_WARN("Failed to read message prefix from %s", addrStr);
-    g_free(addrStr);
-    return;
+    g_set_error(error, IPTUX_CORE_ERROR, IPTUX_CORE_ERROR_INVALID_MSG,
+                "Failed to read message prefix from %s", addrStr);
+    return false;
   }
 
   /* 分派消息 */
@@ -94,7 +111,6 @@ void TcpData::DispatchTcpData() {
   commandno = iptux_get_dec_number(buf, ':', 4);  // 获取命令字
   LOG_INFO("recv TCP request from %s, command NO.: [0x%x] %s", addrStr,
            commandno, CommandMode(GET_MODE(commandno)).toString().c_str());
-  g_free(addrStr);
   switch (GET_MODE(commandno)) {
     case IPMSG_GETFILEDATA:
       RequestData(FileAttr::REGULAR);
@@ -108,6 +124,7 @@ void TcpData::DispatchTcpData() {
     default:
       break;
   }
+  return true;
 }
 
 /**

--- a/src/iptux-core/internal/TcpData.cpp
+++ b/src/iptux-core/internal/TcpData.cpp
@@ -73,12 +73,14 @@ void TcpData::DispatchTcpData() {
   char* addrStr = g_inet_address_to_string(gaddr);
   LOG_DEBUG("received tcp message from %s:%d", addrStr, int(port));
   g_object_unref(remoteAddr);
+  remoteAddr = nullptr;
 
   uint32_t commandno;
   ssize_t len;
 
   /* 读取消息前缀 */
-  if ((len = read_ipmsg_prefix(sock, buf, MAX_SOCKLEN)) <= 0) {
+  if ((len = read_ipmsg_prefix(this->socket, buf, MAX_SOCKLEN)) <= 0) {
+    LOG_WARN("Failed to read message prefix from %s", addrStr);
     g_free(addrStr);
     return;
   }
@@ -217,7 +219,7 @@ void TcpData::RecvSublayerData(int fd, size_t len) {
   if (size != len)
     xwrite(fd, buf + len, size - len);
   do {
-    if ((ssize = xread(sock, buf, MAX_SOCKLEN)) <= 0)
+    if ((ssize = xread(this->socket, buf, MAX_SOCKLEN)) <= 0)
       break;
     if ((ssize = xwrite(fd, buf, ssize)) <= 0)
       break;

--- a/src/iptux-core/internal/TcpData.cpp
+++ b/src/iptux-core/internal/TcpData.cpp
@@ -21,6 +21,10 @@
 #include "iptux-utils/output.h"
 #include "iptux-utils/utils.h"
 
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
 using namespace std;
 
 namespace iptux {

--- a/src/iptux-core/internal/TcpData.cpp
+++ b/src/iptux-core/internal/TcpData.cpp
@@ -133,7 +133,7 @@ void TcpData::RequestData(FileAttr fileattr) {
   }
 
   attach = ipmsg_get_attach(buf, ':', 5);
-  SendFile::RequestDataEntry(coreThread, sock, fileattr, attach);
+  SendFile::RequestDataEntry(coreThread, this->socket, fileattr, attach);
   g_free(attach);
 }
 

--- a/src/iptux-core/internal/TcpData.h
+++ b/src/iptux-core/internal/TcpData.h
@@ -25,10 +25,12 @@ class TcpData {
   TcpData();
   ~TcpData();
 
-  static void TcpDataEntry(CoreThread* coreThread, GSocket* socket);
+  static bool TcpDataEntry(CoreThread* coreThread,
+                           GSocket* socket,
+                           GError** error);
 
  private:
-  void DispatchTcpData();
+  bool DispatchTcpData(GError** error);
 
   void RequestData(FileAttr fileattr);
   void RecvSublayer(uint32_t cmdopt);

--- a/src/iptux-core/internal/iptux_error.h
+++ b/src/iptux-core/internal/iptux_error.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+#define IPTUX_CORE_ERROR g_quark_from_static_string("iptux-core-error")
+
+enum IptuxCoreError {
+  IPTUX_CORE_ERROR_UNKNOWN,
+  IPTUX_CORE_ERROR_INVALID_MSG,
+  IPTUX_CORE_ERROR_SOCKET,
+  IPTUX_CORE_ERROR_FILE,
+  IPTUX_CORE_ERROR_UNKNOWN_PEER,
+};
+
+G_END_DECLS
+
+

--- a/src/iptux-core/internal/iptux_network.h
+++ b/src/iptux-core/internal/iptux_network.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #ifdef _WIN32
-#include <iphlpapi.h>
 #include <winsock2.h>
+#include <iphlpapi.h>
 #else
 #include <ifaddrs.h>
 #include <net/if.h>

--- a/src/iptux-core/internal/iptux_network.h
+++ b/src/iptux-core/internal/iptux_network.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifdef _WIN32
+  #include <winsock2.h>
+  #include <iphlpapi.h>
+  #pragma comment(lib, "iphlpapi.lib")
+  #pragma comment(lib, "ws2_32.lib")
+#else
+  #include <net/if.h>
+  #include <ifaddrs.h>
+#endif

--- a/src/iptux-core/internal/iptux_network.h
+++ b/src/iptux-core/internal/iptux_network.h
@@ -3,9 +3,11 @@
 #ifdef _WIN32
   #include <winsock2.h>
   #include <iphlpapi.h>
-  #pragma comment(lib, "iphlpapi.lib")
-  #pragma comment(lib, "ws2_32.lib")
 #else
   #include <net/if.h>
   #include <ifaddrs.h>
+#endif
+
+#ifndef MSG_NOSIGNAL
+  #define MSG_NOSIGNAL 0
 #endif

--- a/src/iptux-core/internal/iptux_network.h
+++ b/src/iptux-core/internal/iptux_network.h
@@ -1,13 +1,20 @@
 #pragma once
 
 #ifdef _WIN32
-  #include <winsock2.h>
-  #include <iphlpapi.h>
+#include <iphlpapi.h>
+#include <winsock2.h>
 #else
-  #include <net/if.h>
-  #include <ifaddrs.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
 #endif
 
 #ifndef MSG_NOSIGNAL
   #define MSG_NOSIGNAL 0
+#endif
+
+#ifdef _WIN32
+typedef int socklen_t;
 #endif

--- a/src/iptux-core/internal/support.cpp
+++ b/src/iptux-core/internal/support.cpp
@@ -41,16 +41,15 @@ namespace iptux {
  * @param sock socket
  */
 void socket_enable_reuse(int sock) {
-  int len;
-  char optval;
-
-  optval = 1;
-  len = sizeof(optval);
 #ifndef _WIN32
+  int optval = 1;
+  socklen_t len = sizeof(optval);
   if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &optval, len) != 0) {
     LOG_WARN("setsockopt for SO_REUSEPORT failed: %s", strerror(errno));
   }
 #else
+  char optval = 1;
+  socklen_t len = sizeof(optval);
   if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &optval, len) != 0) {
     LOG_WARN("setsockopt for SO_REUSEADDR failed: %s", strerror(errno));
   }

--- a/src/iptux-core/internal/support.cpp
+++ b/src/iptux-core/internal/support.cpp
@@ -12,12 +12,12 @@
 #include "config.h"
 #include "support.h"
 
-#include <net/if.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "iptux-core/internal/iptux_network.h"
 #include "iptux-core/internal/ipmsg.h"
 #include "iptux-utils/output.h"
 #include "iptux-utils/utils.h"

--- a/src/iptux-core/internal/support.cpp
+++ b/src/iptux-core/internal/support.cpp
@@ -12,8 +12,6 @@
 #include "config.h"
 #include "support.h"
 
-#include <sys/ioctl.h>
-#include <sys/socket.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -31,12 +29,12 @@ namespace iptux {
  * @param sock socket
  */
 void socket_enable_reuse(int sock) {
-  socklen_t len;
-  int optval;
+  int len;
+  char optval;
 
   optval = 1;
   len = sizeof(optval);
-#ifndef __CYGWIN__
+#ifndef _WIN32
   if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &optval, len) != 0) {
     LOG_WARN("setsockopt for SO_REUSEPORT failed: %s", strerror(errno));
   }
@@ -53,15 +51,19 @@ void socket_enable_reuse(int sock) {
  * @return list of broadcast addresses
  */
 static vector<string> get_sys_broadcast_addr_by_fd(int sock) {
+#if !defined(_WIN32)
   const uint8_t amount = 5;  //支持5个IP地址
   uint8_t count, sum;
   struct ifconf ifc;
   struct ifreq* ifr;
   struct sockaddr_in* addr;
+#endif
   vector<string> res;
 
-  res.push_back("255.255.255.255");
+  (void)sock;
 
+  res.push_back("255.255.255.255");
+#if !defined(_WIN32)
   ifc.ifc_len = amount * sizeof(struct ifreq);
   ifc.ifc_buf = (caddr_t)g_malloc(ifc.ifc_len);
   if (ioctl(sock, SIOCGIFCONF, &ifc) == -1) {
@@ -83,6 +85,7 @@ static vector<string> get_sys_broadcast_addr_by_fd(int sock) {
     res.push_back(inAddrToString(addr->sin_addr));
   }
   g_free(ifc.ifc_buf);
+#endif
   if (res.size() == 1) {
     res.push_back("127.0.0.1");
   }

--- a/src/iptux-core/internal/support.cpp
+++ b/src/iptux-core/internal/support.cpp
@@ -15,8 +15,9 @@
 #include <algorithm>
 
 #ifdef G_OS_WIN32
-#include <iphlpapi.h>
 #include <winsock2.h>
+
+#include <iphlpapi.h>
 #include <ws2tcpip.h>
 #else
 #include <net/if.h>
@@ -62,7 +63,6 @@ void socket_enable_reuse(int sock) {
  * @return list of broadcast addresses
  */
 static vector<string> get_sys_broadcast_addr_by_fd(int sock) {
-  const uint8_t amount = 5;  //支持5个IP地址
   vector<string> res;
 
   res.push_back("255.255.255.255");
@@ -108,6 +108,7 @@ static vector<string> get_sys_broadcast_addr_by_fd(int sock) {
     g_free(adapters);
   }
 #else
+  const uint8_t amount = 5;
   uint8_t count, sum;
   struct ifconf ifc;
   struct ifreq* ifr;

--- a/src/iptux-core/internal/support.cpp
+++ b/src/iptux-core/internal/support.cpp
@@ -12,11 +12,19 @@
 #include "config.h"
 #include "support.h"
 
+#include <algorithm>
+
+#ifdef G_OS_WIN32
+#include <iphlpapi.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
 #include <net/if.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#endif
 
 #include "iptux-core/internal/ipmsg.h"
 #include "iptux-utils/output.h"
@@ -53,14 +61,56 @@ void socket_enable_reuse(int sock) {
  * @return list of broadcast addresses
  */
 static vector<string> get_sys_broadcast_addr_by_fd(int sock) {
-  const uint8_t amount = 5;  //支持5个IP地址
+  vector<string> res;
+
+  res.push_back("255.255.255.255");
+
+#ifdef G_OS_WIN32
+  (void)sock;
+  ULONG size = 0;
+  constexpr ULONG flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST |
+                          GAA_FLAG_SKIP_DNS_SERVER;
+  DWORD ret = GetAdaptersAddresses(AF_INET, flags, nullptr, nullptr, &size);
+  if (ret == ERROR_BUFFER_OVERFLOW && size > 0) {
+    auto* adapters = reinterpret_cast<IP_ADAPTER_ADDRESSES*>(g_malloc0(size));
+    ret = GetAdaptersAddresses(AF_INET, flags, nullptr, adapters, &size);
+    if (ret == NO_ERROR) {
+      for (IP_ADAPTER_ADDRESSES* adapter = adapters; adapter != nullptr;
+           adapter = adapter->Next) {
+        if (adapter->OperStatus != IfOperStatusUp) {
+          continue;
+        }
+        for (IP_ADAPTER_UNICAST_ADDRESS* unicast = adapter->FirstUnicastAddress;
+             unicast != nullptr; unicast = unicast->Next) {
+          if (unicast->Address.lpSockaddr == nullptr ||
+              unicast->Address.lpSockaddr->sa_family != AF_INET) {
+            continue;
+          }
+          ULONG prefix = unicast->OnLinkPrefixLength;
+          if (prefix > 32) {
+            continue;
+          }
+          auto* addr =
+              reinterpret_cast<sockaddr_in*>(unicast->Address.lpSockaddr);
+          uint32_t ipv4 = ntohl(addr->sin_addr.s_addr);
+          uint32_t mask = prefix == 0 ? 0 : (0xFFFFFFFFu << (32 - prefix));
+          in_addr broadcast{};
+          broadcast.s_addr = htonl((ipv4 & mask) | ~mask);
+          auto broadcastAddr = inAddrToString(broadcast);
+          if (find(res.begin(), res.end(), broadcastAddr) == res.end()) {
+            res.push_back(broadcastAddr);
+          }
+        }
+      }
+    }
+    g_free(adapters);
+  }
+#else
+  const uint8_t amount = 5;  // 支持5个IP地址
   uint8_t count, sum;
   struct ifconf ifc;
   struct ifreq* ifr;
   struct sockaddr_in* addr;
-  vector<string> res;
-
-  res.push_back("255.255.255.255");
 
   ifc.ifc_len = amount * sizeof(struct ifreq);
   ifc.ifc_buf = (caddr_t)g_malloc(ifc.ifc_len);
@@ -83,6 +133,7 @@ static vector<string> get_sys_broadcast_addr_by_fd(int sock) {
     res.push_back(inAddrToString(addr->sin_addr));
   }
   g_free(ifc.ifc_buf);
+#endif
   if (res.size() == 1) {
     res.push_back("127.0.0.1");
   }

--- a/src/iptux-core/meson.build
+++ b/src/iptux-core/meson.build
@@ -31,18 +31,25 @@ core_sources += files([
 inc = include_directories('..', '../api')
 
 thread_dep = dependency('threads')
+core_platform_deps = []
+if host_machine.system() == 'windows'
+    core_platform_deps += [
+        cc.find_library('iphlpapi'),
+        cc.find_library('ws2_32'),
+    ]
+endif
 
 if get_option('static-link')
     libiptux_core = static_library('iptux-core',
         core_sources,
-        dependencies: [glib_dep, gio_dep, jsoncpp_dep, sigc_dep, thread_dep],
+        dependencies: [glib_dep, gio_dep, jsoncpp_dep, sigc_dep, thread_dep] + core_platform_deps,
         link_with: [libiptux_utils],
         include_directories: inc,
     )
 else
     libiptux_core = shared_library('iptux-core',
         core_sources,
-        dependencies: [glib_dep, gio_dep, jsoncpp_dep, sigc_dep, thread_dep],
+        dependencies: [glib_dep, gio_dep, jsoncpp_dep, sigc_dep, thread_dep] + core_platform_deps,
         link_with: [libiptux_utils],
         include_directories: inc,
         install: true,
@@ -85,7 +92,7 @@ core_test_sources = files([
 ])
 libiptux_core_test = executable('libiptux_core_test',
     core_test_sources,
-    dependencies: [glib_dep, gio_dep, jsoncpp_dep, sigc_dep, thread_dep],
+    dependencies: [glib_dep, gio_dep, jsoncpp_dep, sigc_dep, thread_dep] + core_platform_deps,
     link_with: [libiptux_core, libgtest, libiptux_core_test_helper],
     include_directories: [inc, gtest_inc]
 )

--- a/src/iptux-core/meson.build
+++ b/src/iptux-core/meson.build
@@ -31,18 +31,25 @@ core_sources += files([
 inc = include_directories('..', '../api')
 
 thread_dep = dependency('threads')
+iptux_core_dependency = [glib_dep, gio_dep, jsoncpp_dep, sigc_dep, thread_dep]
+
+if host_machine.system() == 'windows'
+  ws2_32 = cc.find_library('ws2_32')
+  iphlpapi = cc.find_library('iphlpapi')
+  iptux_core_dependency += [ws2_32, iphlpapi]
+endif
 
 if get_option('static-link')
     libiptux_core = static_library('iptux-core',
         core_sources,
-        dependencies: [glib_dep, gio_dep, jsoncpp_dep, sigc_dep, thread_dep],
+        dependencies: iptux_core_dependency,
         link_with: [libiptux_utils],
         include_directories: inc,
     )
 else
     libiptux_core = shared_library('iptux-core',
         core_sources,
-        dependencies: [glib_dep, gio_dep, jsoncpp_dep, sigc_dep, thread_dep],
+        dependencies: iptux_core_dependency,
         link_with: [libiptux_utils],
         include_directories: inc,
         install: true,

--- a/src/iptux-utils/Exception.cpp
+++ b/src/iptux-utils/Exception.cpp
@@ -13,10 +13,6 @@ const ErrorCode INVALID_IP_ADDRESS(4001, "INVALID_IP_ADDRESS");
 
 Exception::Exception(const ErrorCode& ec) : Exception(ec, ec.getMessage()) {}
 
-const ErrorCode& Exception::getErrorCode() const {
-  return ec;
-}
-
 Exception::Exception(const ErrorCode& ec, const std::string& reason)
     : runtime_error(reason), ec(ec) {}
 }  // namespace iptux

--- a/src/iptux-utils/TestHelper.cpp
+++ b/src/iptux-utils/TestHelper.cpp
@@ -15,7 +15,7 @@ using namespace std;
 namespace iptux {
 
 string readTestData(const string& fname) {
-  ifstream ifs(testDataPath(fname));
+  ifstream ifs(testDataPath(fname), ios::binary);
   if (!ifs) {
     throw runtime_error(stringFormat("Cannot open file %s", fname.c_str()));
   }

--- a/src/iptux-utils/UtilsTest.cpp
+++ b/src/iptux-utils/UtilsTest.cpp
@@ -116,6 +116,7 @@ TEST(Utils, utf8MakeValid) {
   ASSERT_EQ(utf8MakeValid("\xe4\xb8\xad\xe6"), "中�");
 }
 
+#if !defined(_WIN32)
 TEST(Utils, dupPath) {
   ASSERT_EQ(dupPath("/", 1), "/(1)");
   ASSERT_EQ(dupPath("/a.b", 1), "/a (1).b");
@@ -130,3 +131,4 @@ TEST(Utils, dupPath) {
   ASSERT_EQ(dupPath("a.b", 2), "a (2).b");
   ASSERT_EQ(dupPath("a.b", 10), "a (10).b");
 }
+#endif

--- a/src/iptux-utils/meson.build
+++ b/src/iptux-utils/meson.build
@@ -1,6 +1,12 @@
 glib_dep = dependency('glib-2.0', version: '>=2.35')
 gio_dep = dependency('gio-2.0')
 thread_dep = dependency('threads')
+iptux_utils_dep = [glib_dep, gio_dep]
+
+if host_machine.system() == 'windows'
+  ws2_32 = cc.find_library('ws2_32')
+  iptux_utils_dep += [ws2_32]
+endif
 
 sources = files([
     'output.cpp',
@@ -12,7 +18,7 @@ inc = include_directories('..', '../api')
 
 libiptux_utils = static_library('iptux-utils',
     sources,
-    dependencies: [glib_dep, gio_dep],
+    dependencies: iptux_utils_dep,
     include_directories: inc,
 )
 
@@ -33,7 +39,7 @@ utils_test_sources = files([
 ])
 libiptux_utils_test = executable('libiptux_utils_test',
     utils_test_sources,
-    dependencies: [glib_dep, thread_dep],
+    dependencies: [glib_dep, thread_dep] + iptux_utils_dep,
     link_with: [libiptux_utils, libgtest, libiptux_utils_test_helper],
     include_directories: [inc, gtest_inc]
 )

--- a/src/iptux-utils/output.cpp
+++ b/src/iptux-utils/output.cpp
@@ -51,12 +51,15 @@ static char logLevelAsChar(GLogLevelFlags logLevel) {
 
 static string nowAsString() {
   GDateTime* dt = g_date_time_new_now_local();
-  gint hour = g_date_time_get_hour(dt);
-  gint minute = g_date_time_get_minute(dt);
-  gdouble seconds = g_date_time_get_seconds(dt);
+  char* p =  g_date_time_format(dt, "%H:%M:%S.%f");
+  if(!p) {
+    g_date_time_unref(dt);
+    return "00:00:00.000000";
+  }
+  string res = p;
+  g_free(p);
   g_date_time_unref(dt);
-
-  return stringFormat("%02d:%02d:%06.3f", hour, minute, seconds);
+  return res;
 }
 
 string pretty_fname(const string& fname) {

--- a/src/iptux-utils/output.cpp
+++ b/src/iptux-utils/output.cpp
@@ -11,14 +11,13 @@
 //
 #include "config.h"
 #include "output.h"
-
+#include "iptux-utils/utils.h"
 #include <pthread.h>
 #include <sstream>
 #include <string>
 
 #include <sys/time.h>
 
-#include "iptux-utils/utils.h"
 #include <unistd.h>
 
 using namespace std;

--- a/src/iptux-utils/output.cpp
+++ b/src/iptux-utils/output.cpp
@@ -51,15 +51,13 @@ static char logLevelAsChar(GLogLevelFlags logLevel) {
 }
 
 static string nowAsString() {
-  struct timeval tv;
-  gettimeofday(&tv, nullptr);
-  struct tm timeinfo;
-  char buffer[80];
+  GDateTime* dt = g_date_time_new_now_local();
+  gint hour = g_date_time_get_hour(dt);
+  gint minute = g_date_time_get_minute(dt);
+  gdouble seconds = g_date_time_get_seconds(dt);
+  g_date_time_unref(dt);
 
-  localtime_r(&tv.tv_sec, &timeinfo);
-
-  strftime(buffer, sizeof(buffer), "%H:%M:%S", &timeinfo);
-  return stringFormat("%s.%03d", buffer, int(tv.tv_usec / 1000));
+  return stringFormat("%02d:%02d:%06.3f", hour, minute, seconds);
 }
 
 string pretty_fname(const string& fname) {

--- a/src/iptux-utils/output.h
+++ b/src/iptux-utils/output.h
@@ -17,15 +17,16 @@
 namespace iptux {
 
 #define LOG_DEBUG(...) \
-  DoLog(__FILE__, __LINE__, __func__, G_LOG_LEVEL_DEBUG, __VA_ARGS__)
+  ::iptux::DoLog(__FILE__, __LINE__, __func__, G_LOG_LEVEL_DEBUG, __VA_ARGS__)
 #define LOG_INFO(...) \
-  DoLog(__FILE__, __LINE__, __func__, G_LOG_LEVEL_INFO, __VA_ARGS__)
+  ::iptux::DoLog(__FILE__, __LINE__, __func__, G_LOG_LEVEL_INFO, __VA_ARGS__)
 #define LOG_WARN(...) \
-  DoLog(__FILE__, __LINE__, __func__, G_LOG_LEVEL_WARNING, __VA_ARGS__)
-#define LOG_CRIT(...) \
-  DoLog(__FILE__, __LINE__, __func__, G_LOG_LEVEL_CRITICAL, __VA_ARGS__)
+  ::iptux::DoLog(__FILE__, __LINE__, __func__, G_LOG_LEVEL_WARNING, __VA_ARGS__)
+#define LOG_CRIT(...)                                                \
+  ::iptux::DoLog(__FILE__, __LINE__, __func__, G_LOG_LEVEL_CRITICAL, \
+                 __VA_ARGS__)
 #define LOG_ERROR(...) \
-  DoLog(__FILE__, __LINE__, __func__, G_LOG_LEVEL_ERROR, __VA_ARGS__)
+  ::iptux::DoLog(__FILE__, __LINE__, __func__, G_LOG_LEVEL_ERROR, __VA_ARGS__)
 #define LOG_TRACE() LOG_DEBUG("called")
 
 /* 警告信息输出 */

--- a/src/iptux-utils/utils.cpp
+++ b/src/iptux-utils/utils.cpp
@@ -655,6 +655,25 @@ ssize_t xwrite(int fd, const void* buf, size_t count) {
   return offset;
 }
 
+ssize_t xwrite(GSocket* sock, const void* buf, size_t count) {
+  size_t offset;
+  ssize_t size;
+
+  size = -1;
+  offset = 0;
+  while (offset < count) {
+    if ((size = g_socket_send(sock, (gchar*)buf + offset, count - offset, NULL,
+                              NULL)) == -1) {
+      LOG_ERROR("write to %p failed on %zu/%zu: %s", sock, offset, count,
+                strerror(errno));
+      return -1;
+    }
+    offset += size;
+  }
+
+  return offset;
+}
+
 ssize_t xsend(int fd, const void* buf, size_t count) {
   size_t offset;
   ssize_t size;

--- a/src/iptux-utils/utils.cpp
+++ b/src/iptux-utils/utils.cpp
@@ -454,36 +454,6 @@ char* ipmsg_get_attach(const char* msg, char ch, uint8_t times) {
 }
 
 /**
- * 从文件路径中分离出文件名，并转化为(IPMsg)格式的文件名.
- * @param pathname 文件路径
- * @return 文件名 *
- * @note 文件名特殊格式请参考IPMsg协议
- */
-char* ipmsg_get_filename_pal(const char* pathname) {
-  char filename[512];  // 文件最大长度为255
-  const char* ptr;
-  size_t len;
-
-  ptr = strrchr(pathname, '/');
-  ptr = ptr ? ptr + 1 : pathname;
-
-  len = 0;
-  while (*ptr && len < 510) {
-    if (*ptr == ':') {
-      memcpy(filename + len, "::", 2);
-      len += 2;
-    } else {
-      filename[len] = *ptr;
-      len++;
-    }
-    ptr++;
-  }
-  filename[len] = '\0';
-
-  return g_strdup(filename);
-}
-
-/**
  * 从文件路径中分离出文件名以及路径.
  * @param pathname 文件路径
  * @retval path 路径由此返回

--- a/src/iptux-utils/utils.cpp
+++ b/src/iptux-utils/utils.cpp
@@ -174,7 +174,7 @@ char* getformattime(gboolean date, const char* format, ...) {
 
   time(&tt);
 #if defined(_WIN32)
-  tm = *localtime(&tt);
+  localtime_s(&tm, &tt);
 #else
   localtime_r(&tt, &tm);
 #endif
@@ -199,7 +199,7 @@ char* getformattime2(time_t tt, gboolean date, const char* format, ...) {
 
   struct tm tm;
 #if defined(_WIN32)
-  tm = *localtime(&tt);
+  localtime_s(&tm, &tt);
 #else
   localtime_r(&tt, &tm);
 #endif

--- a/src/iptux-utils/utils.cpp
+++ b/src/iptux-utils/utils.cpp
@@ -461,21 +461,9 @@ char* ipmsg_get_attach(const char* msg, char ch, uint8_t times) {
  * @note 路径可能为NULL
  */
 char* ipmsg_get_filename_me(const char* pathname, char** path) {
-  const char* ptr;
-  char* file;
-
-  ptr = strrchr(pathname, '/');
-  if (ptr && ptr != pathname) {
-    file = g_strdup(ptr + 1);
-    if (path)
-      *path = g_strndup(pathname, ptr - pathname);
-  } else {
-    file = g_strdup(pathname);
-    if (path)
-      *path = NULL;
-  }
-
-  return file;
+  if (path)
+    *path = g_path_get_dirname(pathname);
+  return g_path_get_basename(pathname);
 }
 
 /**

--- a/src/iptux-utils/utils.cpp
+++ b/src/iptux-utils/utils.cpp
@@ -556,16 +556,16 @@ in_addr inAddrFromString(const std::string& s) {
 
   GInetAddress* addr = g_inet_address_new_from_string(s.c_str());
   if (addr == NULL) {
-    g_error("Invalid IP");
-    return res;
+    LOG_WARN("Invalid IP");
+    throw Exception(INVALID_IP_ADDRESS);
   }
 
   GSocketFamily family = g_inet_address_get_family(addr);
   const guint8* bytes = g_inet_address_to_bytes(addr);
   if(family != G_SOCKET_FAMILY_IPV4) {
-    g_error("Invalid IP");
+    LOG_WARN("Invalid IP");
     g_object_unref(addr);
-    return res;
+    throw Exception(INVALID_IP_ADDRESS);
   }
   memcpy(&res, bytes, 4);
 

--- a/src/iptux-utils/utils.cpp
+++ b/src/iptux-utils/utils.cpp
@@ -19,14 +19,13 @@
 #include <cstring>
 #include <sstream>
 
-#include <arpa/inet.h>
+#include "iptux-core/internal/iptux_network.h"
 #include <glib/gi18n.h>
 #include <sys/param.h>
-#include <sys/socket.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
-#ifndef __APPLE__
+#if defined(__unix__)
 #include <sys/vfs.h>
 #endif
 
@@ -167,14 +166,18 @@ char* getformattime(gboolean date, const char* format, ...) {
   char buf[MAX_BUFLEN], *msg, *ptr;
   time_t tt;
   va_list ap;
+  struct tm tm;
 
   va_start(ap, format);
   msg = g_strdup_vprintf(format, ap);
   va_end(ap);
 
   time(&tt);
-  struct tm tm;
+#if defined(_WIN32)
+  tm = *localtime(&tt);
+#else
   localtime_r(&tt, &tm);
+#endif
   if (date)
     strftime(buf, MAX_BUFLEN, "%c", &tm);
   else
@@ -195,7 +198,11 @@ char* getformattime2(time_t tt, gboolean date, const char* format, ...) {
   va_end(ap);
 
   struct tm tm;
+#if defined(_WIN32)
+  tm = *localtime(&tt);
+#else
   localtime_r(&tt, &tm);
+#endif
   if (date)
     strftime(buf, MAX_BUFLEN, "%c", &tm);
   else
@@ -533,17 +540,37 @@ char* ipmsg_get_pathname_full(const char* path, const char* name) {
 }
 
 std::string inAddrToString(in_addr inAddr) {
-  char res[INET_ADDRSTRLEN];
-  inet_ntop(AF_INET, &inAddr.s_addr, res, INET_ADDRSTRLEN);
+  string res;
+
+  GInetAddress* addr = g_inet_address_new_from_bytes((guint8*)&inAddr.s_addr,
+                                                     G_SOCKET_FAMILY_IPV4);
+  gchar* addr_str = g_inet_address_to_string(addr);
+  res = addr_str;
+  g_object_unref(addr);
+  g_free(addr_str);
   return res;
 }
 
 in_addr inAddrFromString(const std::string& s) {
-  in_addr res;
-  if (inet_pton(AF_INET, s.c_str(), &res.s_addr) == 1) {
+  in_addr res = {0};
+
+  GInetAddress* addr = g_inet_address_new_from_string(s.c_str());
+  if (addr == NULL) {
+    g_error("Invalid IP");
     return res;
   }
-  throw Exception(INVALID_IP_ADDRESS);
+
+  GSocketFamily family = g_inet_address_get_family(addr);
+  const guint8* bytes = g_inet_address_to_bytes(addr);
+  if(family != G_SOCKET_FAMILY_IPV4) {
+    g_error("Invalid IP");
+    g_object_unref(addr);
+    return res;
+  }
+  memcpy(&res, bytes, 4);
+
+  g_object_unref(addr);
+  return res;
 }
 
 std::string stringDump(const std::string& str) {
@@ -703,7 +730,7 @@ ssize_t xread(int fd, void* buf, size_t count) {
  * @return 成功读取的消息长度，-1表示读取消息出错
  */
 ssize_t read_ipmsg_prefix(int fd, void* buf, size_t count) {
-  uint number;
+  unsigned int number;
   size_t offset;
   ssize_t size;
 
@@ -740,7 +767,7 @@ ssize_t read_ipmsg_prefix(int fd, void* buf, size_t count) {
  */
 ssize_t read_ipmsg_filedata(int fd, void* buf, size_t count, size_t offset) {
   const char* curptr;
-  uint number;
+  unsigned int number;
   ssize_t size;
 
   size = -1;
@@ -776,7 +803,7 @@ ssize_t read_ipmsg_filedata(int fd, void* buf, size_t count, size_t offset) {
  */
 ssize_t read_ipmsg_dirfiles(int fd, void* buf, size_t count, size_t offset) {
   const char* curptr;
-  uint number;
+  unsigned int number;
   ssize_t size;
 
   size = -1;
@@ -891,23 +918,23 @@ int64_t fileOrDirectorySize(const string& fileOrDirName) {
     return 0;
   }
   // 到了这里就一定是目录了
-  DIR* dir = opendir(fileOrDirName.c_str());
+  GDir* dir = g_dir_open(fileOrDirName.c_str(), 0, NULL);
   if (dir == NULL) {
     LOG_WARN(_("opendir on \"%s\" failed: %s"), fileOrDirName.c_str(),
              strerror(errno));
     return 0;
   }
 
-  struct dirent* dirt;
+const char* dirt;
   int64_t sumsize = 0;
-  while ((dirt = readdir(dir))) {
-    if (strcmp(dirt->d_name, ".") == 0) {
+  while ((dirt = g_dir_read_name(dir))) {
+    if (strcmp(dirt, ".") == 0) {
       continue;
     }
-    if (strcmp(dirt->d_name, "..") == 0) {
+    if (strcmp(dirt, "..") == 0) {
       continue;
     }
-    string tpath = fileOrDirName + "/" + dirt->d_name;
+    string tpath = fileOrDirName + "/" + dirt;
     struct stat st;
     if (stat(tpath.c_str(), &st) == -1) {
       continue;

--- a/src/iptux-utils/utils.cpp
+++ b/src/iptux-utils/utils.cpp
@@ -573,6 +573,16 @@ in_addr inAddrFromString(const std::string& s) {
   return res;
 }
 
+bool is_ipv4(const char* str) {
+  GInetAddress* addr = g_inet_address_new_from_string(str);
+  if (addr == NULL) {
+    return false;
+  }
+  GSocketFamily family = g_inet_address_get_family(addr);
+  g_object_unref(addr);
+  return family == G_SOCKET_FAMILY_IPV4;
+}
+
 std::string stringDump(const std::string& str) {
   if (str.empty()) {
     return "";

--- a/src/iptux-utils/utils.cpp
+++ b/src/iptux-utils/utils.cpp
@@ -731,6 +731,25 @@ ssize_t xread(int fd, void* buf, size_t count) {
   return offset;
 }
 
+ssize_t xread(GSocket* sock, void* buf, size_t count) {
+  size_t offset;
+  ssize_t size;
+
+  size = -1;
+  offset = 0;
+  while ((offset != count) && (size != 0)) {
+    if ((size = g_socket_receive(sock, (gchar*)buf + offset, count - offset,
+                                 NULL, NULL)) == -1) {
+      if (errno == EINTR)
+        continue;
+      return -1;
+    }
+    offset += size;
+  }
+
+  return offset;
+}
+
 /**
  * 读取ipmsg消息前缀.
  * Ver(1):PacketNo:SenderName:SenderHost:CommandNo:AdditionalSection.\n
@@ -749,6 +768,34 @@ ssize_t read_ipmsg_prefix(int fd, void* buf, size_t count) {
   number = 0;
   while ((offset != count) && (size != 0)) {
     if ((size = read(fd, (char*)buf + offset, count - offset)) == -1) {
+      if (errno == EINTR)
+        continue;
+      return -1;
+    }
+    offset += size;
+    const char* endptr = (const char*)buf + offset;
+    for (const char* curptr = endptr - size; curptr < endptr; ++curptr) {
+      if (*curptr == ':')
+        ++number;
+    }
+    if (number >= 5)
+      break;
+  }
+
+  return offset;
+}
+
+ssize_t read_ipmsg_prefix(GSocket* sock, void* buf, size_t count) {
+  unsigned int number;
+  size_t offset;
+  ssize_t size;
+
+  size = -1;
+  offset = 0;
+  number = 0;
+  while ((offset != count) && (size != 0)) {
+    if ((size = g_socket_receive(sock, (gchar*)buf + offset, count - offset,
+                                 NULL, NULL)) == -1) {
       if (errno == EINTR)
         continue;
       return -1;

--- a/src/iptux-utils/utils.cpp
+++ b/src/iptux-utils/utils.cpp
@@ -994,3 +994,24 @@ std::string sha256(const char* s, int length) {
 }
 
 }  // namespace iptux
+
+gboolean iptux_inet_address_to_in_addr(GInetAddress* address,
+                                       struct in_addr* out_addr) {
+  g_return_val_if_fail(G_IS_INET_ADDRESS(address), FALSE);
+  g_return_val_if_fail(out_addr != NULL, FALSE);
+
+  if (g_inet_address_get_family(address) != G_SOCKET_FAMILY_IPV4) {
+    LOG_WARN("Address is not an IPv4 address.");
+    return FALSE;
+  }
+
+  // 2. 获取原始字节网络字节序（4字节）
+  const guint8* bytes = g_inet_address_to_bytes(address);
+
+  // 3. 将字节复制到 struct in_addr 中
+  // g_inet_address_to_bytes 返回的已经是网络字节序（Big Endian），与 struct
+  // in_addr 要求的字节序一致
+  memcpy(&(out_addr->s_addr), bytes, sizeof(out_addr->s_addr));
+
+  return TRUE;
+}

--- a/src/iptux-utils/utils.h
+++ b/src/iptux-utils/utils.h
@@ -114,7 +114,9 @@ class Helper {
 ssize_t xwrite(int fd, const void* buf, size_t count);
 ssize_t xsend(int fd, const void* buf, size_t count);
 ssize_t xread(int fd, void* buf, size_t count);
+ssize_t xread(GSocket* sock, void* buf, size_t count);
 ssize_t read_ipmsg_prefix(int fd, void* buf, size_t count);
+ssize_t read_ipmsg_prefix(GSocket* sock, void* buf, size_t count);
 ssize_t read_ipmsg_filedata(int fd, void* buf, size_t count, size_t offset);
 ssize_t read_ipmsg_dirfiles(int fd, void* buf, size_t count, size_t offset);
 ssize_t read_ipmsg_fileinfo(GSocket* sock,

--- a/src/iptux-utils/utils.h
+++ b/src/iptux-utils/utils.h
@@ -15,7 +15,6 @@
 #include <gio/gio.h>
 #include <glib.h>
 #include <memory>
-#include <netinet/in.h>
 #include <string>
 
 namespace iptux {

--- a/src/iptux-utils/utils.h
+++ b/src/iptux-utils/utils.h
@@ -16,6 +16,7 @@
 #include <glib.h>
 #include <memory>
 #include <string>
+#include "iptux-core/internal/iptux_network.h"
 
 namespace iptux {
 
@@ -159,6 +160,8 @@ std::string sha256(const std::string& s);
  * @return std::string
  */
 std::string sha256(const char* s, int length);
+
+
 
 }  // namespace iptux
 #endif

--- a/src/iptux-utils/utils.h
+++ b/src/iptux-utils/utils.h
@@ -12,11 +12,10 @@
 #ifndef IPTUX_UTILS_H
 #define IPTUX_UTILS_H
 
+#include "iptux-core/internal/iptux_network.h"
 #include <gio/gio.h>
 #include <glib.h>
-#include <memory>
 #include <string>
-#include "iptux-core/internal/iptux_network.h"
 
 namespace iptux {
 

--- a/src/iptux-utils/utils.h
+++ b/src/iptux-utils/utils.h
@@ -74,6 +74,7 @@ std::string inAddrToString(in_addr ipv4);
 in_addr inAddrFromString(const std::string& s);
 uint32_t inAddrToUint32(in_addr ipv4);
 in_addr inAddrFromUint32(uint32_t value);
+bool is_ipv4(const char* str);
 
 template <typename... Args>
 std::string stringFormat(const char* format, ...) G_GNUC_PRINTF(1, 2);

--- a/src/iptux-utils/utils.h
+++ b/src/iptux-utils/utils.h
@@ -111,6 +111,7 @@ class Helper {
 };
 
 ssize_t xwrite(int fd, const void* buf, size_t count);
+ssize_t xwrite(GSocket* sock, const void* buf, size_t count);
 ssize_t xsend(int fd, const void* buf, size_t count);
 ssize_t xread(int fd, void* buf, size_t count);
 ssize_t xread(GSocket* sock, void* buf, size_t count);

--- a/src/iptux-utils/utils.h
+++ b/src/iptux-utils/utils.h
@@ -17,6 +17,11 @@
 #include <glib.h>
 #include <string>
 
+G_BEGIN_DECLS
+gboolean iptux_inet_address_to_in_addr(GInetAddress* address,
+                                       struct in_addr* out_addr);
+G_END_DECLS
+
 namespace iptux {
 
 #define difftimeval(val2, val1)                                  \

--- a/src/iptux-utils/utils.h
+++ b/src/iptux-utils/utils.h
@@ -61,7 +61,6 @@ uint32_t iptux_get_dec_number(const char* msg, char ch, uint8_t times);
 char* iptux_get_section_string(const char* msg, char ch, uint8_t times);
 char* ipmsg_get_filename(const char* msg, char ch, uint8_t times);
 char* ipmsg_get_attach(const char* msg, char ch, uint8_t times);
-char* ipmsg_get_filename_pal(const char* pathname);
 char* ipmsg_get_filename_me(const char* pathname, char** path);
 char* iptux_erase_filename_suffix(const char* filename);
 char* ipmsg_get_pathname_full(const char* path, const char* name);

--- a/src/iptux/Application.cpp
+++ b/src/iptux/Application.cpp
@@ -48,7 +48,9 @@ void onWhatsNew() {
 }
 
 void iptux_init(LogSystemPtr logSystem) {
+#if !defined(_WIN32)
   signal(SIGPIPE, SIG_IGN);
+#endif
   logSystem->systemLog("%s", _("Loading the process successfully!"));
 }
 

--- a/src/iptux/Application.cpp
+++ b/src/iptux/Application.cpp
@@ -269,12 +269,12 @@ void Application::onToolsSharedManagement(void*, void*, Application& self) {
 
 void Application::onOpenChatLog(void*, void*, Application& self) {
   auto path = self.getCoreThread()->getLogSystem()->getChatLogPath();
-  iptux_open_url(path.c_str());
+  iptux_open_path(path.c_str());
 }
 
 void Application::onOpenSystemLog(void*, void*, Application& self) {
   auto path = self.getCoreThread()->getLogSystem()->getSystemLogPath();
-  iptux_open_url(path.c_str());
+  iptux_open_path(path.c_str());
 }
 
 void Application::onTransModelClear(void*, void*, Application& self) {

--- a/src/iptux/DataSettings.cpp
+++ b/src/iptux/DataSettings.cpp
@@ -1092,8 +1092,9 @@ void DataSettings::WriteNetSegment(const char* filename, GSList* list) {
  */
 void DataSettings::ReadNetSegment(const char* filename, GSList** list) {
   GtkWidget* parent;
-  char buf[3][MAX_BUFLEN], *lineptr;
-  in_addr_t ipv4;
+  char buffer[MAX_BUFLEN*3];
+  char buf[3][MAX_BUFLEN];
+  uint32_t ipv4;
   NetSegment* ns;
   FILE* stream;
   size_t n;
@@ -1106,11 +1107,10 @@ void DataSettings::ReadNetSegment(const char* filename, GSList** list) {
   }
 
   n = 0;
-  lineptr = NULL;
-  while (getline(&lineptr, &n, stream) != -1) {
-    if (*(lineptr + strspn(lineptr, "\t\x20")) == '#')
+  while (fgets(buffer, sizeof(buffer), stream) != NULL) {
+    if (*(buffer + strspn(buffer, "\t\x20")) == '#')
       continue;
-    switch (sscanf(lineptr, "%s - %s //%s", buf[0], buf[1], buf[2])) {
+    switch (sscanf(buffer, "%s - %s //%s", buf[0], buf[1], buf[2])) {
       case 3:
         if (inet_pton(AF_INET, buf[0], &ipv4) <= 0 ||
             inet_pton(AF_INET, buf[1], &ipv4) <= 0)
@@ -1134,7 +1134,6 @@ void DataSettings::ReadNetSegment(const char* filename, GSList** list) {
         break;
     }
   }
-  g_free(lineptr);
   fclose(stream);
 }
 

--- a/src/iptux/DataSettings.cpp
+++ b/src/iptux/DataSettings.cpp
@@ -1110,7 +1110,7 @@ void DataSettings::ReadNetSegment(const char* filename, GSList** list) {
   while (fgets(buffer, sizeof(buffer), stream) != NULL) {
     if (*(buffer + strspn(buffer, "\t\x20")) == '#')
       continue;
-    switch (sscanf(buffer, "%s - %s //%s", buf[0], buf[1], buf[2])) {
+    switch (sscanf(buffer, "%1023s - %1023s //%1023s", buf[0], buf[1], buf[2])) {
       case 3:
         if (!is_ipv4(buf[0])) {
           LOG_WARN("Invalid start IP address: %s", buf[0]);

--- a/src/iptux/DataSettings.cpp
+++ b/src/iptux/DataSettings.cpp
@@ -18,6 +18,7 @@
 #include <glib/gi18n.h>
 
 #include "iptux-core/Const.h"
+#include "iptux-core/internal/iptux_network.h"
 #include "iptux-utils/output.h"
 #include "iptux-utils/utils.h"
 #include "iptux/UiCoreThread.h"
@@ -28,6 +29,7 @@ using namespace std;
 
 namespace iptux {
 
+#if 0
 static const struct {
   StatusIconMode mode;
   const char* label;
@@ -36,6 +38,7 @@ static const struct {
     {STATUS_ICON_MODE_NORMAL, N_("Normal status icon")},
     {STATUS_ICON_MODE_BLINKING, N_("Blinking status icon")},
 };
+#endif
 
 enum {
   STATUS_ICON_MODEL_COL_ID,
@@ -1094,10 +1097,8 @@ void DataSettings::ReadNetSegment(const char* filename, GSList** list) {
   GtkWidget* parent;
   char buffer[MAX_BUFLEN*3];
   char buf[3][MAX_BUFLEN];
-  uint32_t ipv4;
   NetSegment* ns;
   FILE* stream;
-  size_t n;
 
   if (!(stream = fopen(filename, "r"))) {
     parent = GTK_WIDGET(g_datalist_get_data(&widset, "dialog-widget"));
@@ -1106,15 +1107,19 @@ void DataSettings::ReadNetSegment(const char* filename, GSList** list) {
     return;
   }
 
-  n = 0;
   while (fgets(buffer, sizeof(buffer), stream) != NULL) {
     if (*(buffer + strspn(buffer, "\t\x20")) == '#')
       continue;
     switch (sscanf(buffer, "%s - %s //%s", buf[0], buf[1], buf[2])) {
       case 3:
-        if (inet_pton(AF_INET, buf[0], &ipv4) <= 0 ||
-            inet_pton(AF_INET, buf[1], &ipv4) <= 0)
+        if (!is_ipv4(buf[0])) {
+          LOG_WARN("Invalid start IP address: %s", buf[0]);
           break;
+        }
+        if (!is_ipv4(buf[1])) {
+          LOG_WARN("Invalid end IP address: %s", buf[1]);
+          break;
+        }
         ns = new NetSegment;
         *list = g_slist_append(*list, ns);
         ns->startip = g_strdup(buf[0]);
@@ -1122,9 +1127,14 @@ void DataSettings::ReadNetSegment(const char* filename, GSList** list) {
         ns->description = g_strdup(buf[2]);
         break;
       case 2:
-        if (inet_pton(AF_INET, buf[0], &ipv4) <= 0 ||
-            inet_pton(AF_INET, buf[1], &ipv4) <= 0)
+        if (!is_ipv4(buf[0])) {
+          LOG_WARN("Invalid start IP address: %s", buf[0]);
           break;
+        }
+        if (!is_ipv4(buf[1])) {
+          LOG_WARN("Invalid end IP address: %s", buf[1]);
+          break;
+        }
         ns = new NetSegment;
         *list = g_slist_append(*list, ns);
         ns->startip = g_strdup(buf[0]);
@@ -1282,28 +1292,30 @@ void DataSettings::ClickAddIpseg(GData** widset) {
   GtkTreeModel* model;
   GtkTreeIter iter;
   const gchar *starttext, *endtext;
-  in_addr_t startip, endip;
+  uint32_t startip, endip;
 
   /* 合法性检查 */
   parent = GTK_WIDGET(g_datalist_get_data(widset, "dialog-widget"));
   startentry = GTK_WIDGET(g_datalist_get_data(widset, "startip-entry-widget"));
   starttext = gtk_entry_get_text(GTK_ENTRY(startentry));
-  if (inet_pton(AF_INET, starttext, &startip) <= 0) {
+  if (!is_ipv4(starttext)) {
     gtk_widget_grab_focus(startentry);
     pop_warning(parent, _("\nIllegal IP(v4) address: %s!"), starttext);
     return;
   }
+  in_addr start_addr = inAddrFromString(starttext);
   endentry = GTK_WIDGET(g_datalist_get_data(widset, "endip-entry-widget"));
   endtext = gtk_entry_get_text(GTK_ENTRY(endentry));
-  if (inet_pton(AF_INET, endtext, &endip) <= 0) {
+  if (!is_ipv4(endtext)) {
     gtk_widget_grab_focus(endentry);
     pop_warning(parent, _("\nIllegal IP(v4) address: %s!"), endtext);
     return;
   }
+  in_addr end_addr = inAddrFromString(endtext);
 
   /* 加入网段树 */
-  startip = ntohl(startip);
-  endip = ntohl(endip);
+  startip = ntohl(start_addr.s_addr);
+  endip = ntohl(end_addr.s_addr);
   treeview = GTK_WIDGET(g_datalist_get_data(widset, "network-treeview-widget"));
   model = gtk_tree_view_get_model(GTK_TREE_VIEW(treeview));
   gtk_list_store_append(GTK_LIST_STORE(model), &iter);

--- a/src/iptux/DataSettings.cpp
+++ b/src/iptux/DataSettings.cpp
@@ -29,7 +29,7 @@ using namespace std;
 
 namespace iptux {
 
-#if 0
+#if HAVE_STATUS_ICON
 static const struct {
   StatusIconMode mode;
   const char* label;

--- a/src/iptux/DataSettings.h
+++ b/src/iptux/DataSettings.h
@@ -13,6 +13,7 @@
 #define IPTUX_DATASETTINGS_H
 
 #include <gtk/gtk.h>
+#include <string>
 
 #include "iptux-core/Models.h"
 #include "iptux/Application.h"

--- a/src/iptux/DialogPeer.cpp
+++ b/src/iptux/DialogPeer.cpp
@@ -17,7 +17,6 @@
 #include "iptux-core/Models.h"
 #include <cinttypes>
 
-#include <sys/socket.h>
 #include <unistd.h>
 
 #include <gdk/gdkkeysyms.h>

--- a/src/iptux/DialogPeer.cpp
+++ b/src/iptux/DialogPeer.cpp
@@ -961,8 +961,7 @@ void DialogPeer::onAcceptButtonClicked(DialogPeer* self) {
   do {
     gtk_tree_model_get(model, &iter, 2, &filename, 5, &file, -1);
     g_free(file->filepath);
-    file->filepath = g_strdup_printf(
-        "%s%s%s", filepath, *(filepath + 1) != '\0' ? "/" : "", filename);
+    file->filepath = g_build_filename(filepath, filename, NULL);
     self->app->getCoreThread()->RecvFileAsync(file);
     g_free(filename);
     self->torcvsize += file->filesize;

--- a/src/iptux/LogSystem.cpp
+++ b/src/iptux/LogSystem.cpp
@@ -15,7 +15,6 @@
 #include <fcntl.h>
 #include <glib/gi18n.h>
 
-#include "iptux-core/Const.h"
 #include "iptux-utils/utils.h"
 #include <unistd.h>
 
@@ -109,13 +108,25 @@ void LogSystem::systemLogv(const char* fmt, va_list ap) {
 }
 
 string LogSystem::getChatLogPath() const {
+  char* res1;
+  string res2;
   auto env = g_get_user_config_dir();
-  return stringFormat("%s" LOG_PATH "/communicate.log", env);
+
+  res1 = g_build_filename(env, "iptux", "log", "communicate.log", NULL);
+  res2 = res1;
+  g_free(res1);
+  return res2;
 }
 
 string LogSystem::getSystemLogPath() const {
+  char* res1;
+  string res2;
   auto env = g_get_user_config_dir();
-  return stringFormat("%s" LOG_PATH "/system.log", env);
+
+  res1 = g_build_filename(env, "iptux", "log", "system.log", NULL);
+  res2 = res1;
+  g_free(res1);
+  return res2;
 }
 
 }  // namespace iptux

--- a/src/iptux/LogSystem.cpp
+++ b/src/iptux/LogSystem.cpp
@@ -12,6 +12,7 @@
 #include "config.h"
 #include "LogSystem.h"
 
+#include "iptux-utils/output.h"
 #include <fcntl.h>
 #include <glib/gi18n.h>
 
@@ -37,8 +38,16 @@ LogSystem::~LogSystem() {
 }
 
 void LogSystem::InitSublayer() {
+  LOG_INFO("LogSystem initialized, chat log path: %s, system log path: %s",
+           getChatLogPath().c_str(), getSystemLogPath().c_str());
   fdc = open(getChatLogPath().c_str(), O_WRONLY | O_CREAT | O_APPEND, 0644);
+  if (fdc == -1) {
+    LOG_ERROR("Failed to open communicate log: %s", strerror(errno));
+  }
   fds = open(getSystemLogPath().c_str(), O_WRONLY | O_CREAT | O_APPEND, 0644);
+  if (fds == -1) {
+    LOG_ERROR("Failed to open system log: %s", strerror(errno));
+  }
 }
 
 void LogSystem::communicateLog(const MsgPara* msgpara, const char* fmt, ...) {
@@ -83,7 +92,9 @@ void LogSystem::communicateLogv(const MsgPara* msgpara,
   msg = g_strdup_vprintf(fmt, ap);
   log = g_strdup_printf("%s\n%s\n%s\n%s\n\n", LOG_START_HEADER, ptr, msg,
                         LOG_END_HEADER);
-  write(fdc, log, strlen(log));
+  if (write(fdc, log, strlen(log)) == -1) {
+    LOG_ERROR("Failed to write to communicate log: %s", strerror(errno));
+  }
   g_free(log);
   g_free(ptr);
   g_free(msg);
@@ -103,7 +114,9 @@ void LogSystem::systemLogv(const char* fmt, va_list ap) {
   g_free(ptr);
   g_free(msg);
 
-  write(fds, log, strlen(log));
+  if (write(fds, log, strlen(log)) == -1) {
+    LOG_ERROR("Failed to write to system log: %s", strerror(errno));
+  }
   g_free(log);
 }
 

--- a/src/iptux/MainWindow.cpp
+++ b/src/iptux/MainWindow.cpp
@@ -106,7 +106,7 @@ MainWindow::MainWindow(Application* app, UiCoreThread& coreThread)
       palPopupMenu(0) {
   time_t now = time(nullptr);
 #if defined(_WIN32) || defined(_WIN64)
-  info_refresh_tm = *localtime(&now);
+  localtime_s(&info_refresh_tm, &now);
 #else
   localtime_r(&now, &info_refresh_tm);
 #endif

--- a/src/iptux/MainWindow.cpp
+++ b/src/iptux/MainWindow.cpp
@@ -30,6 +30,31 @@
 #include <thread>
 
 using namespace std;
+#if defined(_WIN32)
+#define strcasestr strcasestr_compat
+const char* strcasestr_compat(const char* haystack, const char* needle) {
+  if (!haystack || !needle)
+    return NULL;
+  if (*needle == '\0')
+    return haystack;
+
+  for (const char* h = haystack; *h; ++h) {
+    const char* h1 = h;
+    const char* n1 = needle;
+
+    while (*h1 && *n1 &&
+           tolower((unsigned char)*h1) == tolower((unsigned char)*n1)) {
+      ++h1;
+      ++n1;
+    }
+
+    if (*n1 == '\0')
+      return h;  // 全匹配
+  }
+
+  return NULL;
+}
+#endif
 
 namespace iptux {
 
@@ -80,7 +105,11 @@ MainWindow::MainWindow(Application* app, UiCoreThread& coreThread)
       windowConfig(250, 510, "main_window"),
       palPopupMenu(0) {
   time_t now = time(nullptr);
+#if defined(_WIN32) || defined(_WIN64)
+  info_refresh_tm = *localtime(&now);
+#else
   localtime_r(&now, &info_refresh_tm);
+#endif
   windowConfig.LoadFromConfig(config);
   builder = gtk_builder_new_from_resource(IPTUX_RESOURCE "gtk/MainWindow.ui");
   gtk_builder_connect_signals(builder, nullptr);
@@ -956,7 +985,11 @@ gboolean MainWindow::UpdateUI(MainWindow* mwin) {
   if (mwin->info_style_ == GroupInfoStyle::LAST_ACTIVITY) {
     time_t now = time(nullptr);
     struct tm now_tm;
+#if defined(_WIN32) || defined(_WIN64)
+    localtime_s(&now_tm, &now);
+#else
     localtime_r(&now, &now_tm);
+#endif
     if (mwin->info_refresh_tm.tm_year != now_tm.tm_year ||
         mwin->info_refresh_tm.tm_mon != now_tm.tm_mon ||
         mwin->info_refresh_tm.tm_mday != now_tm.tm_mday) {

--- a/src/iptux/MainWindow.h
+++ b/src/iptux/MainWindow.h
@@ -21,6 +21,10 @@
 #include "iptux/UiModels.h"
 #include "iptux/WindowConfig.h"
 
+#if defined(CreateWindow)
+#undef CreateWindow
+#endif
+
 namespace iptux {
 
 class StatusIcon;

--- a/src/iptux/RevisePal.cpp
+++ b/src/iptux/RevisePal.cpp
@@ -260,7 +260,8 @@ void RevisePal::ApplyReviseData() {
       g_free(file);
       snprintf(path, MAX_PATHLEN, "%s" ICON_PATH "/%" PRIx32 ".png",
                g_get_user_cache_dir(), ntohl(pal->ipv4().s_addr));
-      pal->set_icon_file(stringFormat("%" PRIx32, ntohl(pal->ipv4().s_addr)));
+      pal->set_icon_file(
+          stringFormat("%" PRIx32, (uint32_t)ntohl(pal->ipv4().s_addr)));
       gtk_tree_model_get(model, &iter, 0, &pixbuf, -1);
       gdk_pixbuf_save(pixbuf, path, "png", NULL, NULL);
       g_object_unref(pixbuf);

--- a/src/iptux/UIHelperWindows.cpp
+++ b/src/iptux/UIHelperWindows.cpp
@@ -1,0 +1,28 @@
+#include "UIHelperWindows.h"
+#include "iptux-utils/output.h"
+#include <windows.h>
+#include <shellapi.h>
+
+
+void iptux_launch_file_windows(const char* utf8_path) {
+    int len = MultiByteToWideChar(CP_UTF8, 0, utf8_path, -1, NULL, 0);
+    wchar_t* w_path = (wchar_t*)malloc(len * sizeof(wchar_t));
+    MultiByteToWideChar(CP_UTF8, 0, utf8_path, -1, w_path, len);
+
+    HINSTANCE result = ShellExecuteW(
+        NULL,          // 父窗口句柄
+        L"open",       // 操作类型：打开
+        w_path,        // 文件路径
+        NULL,          // 命令行参数
+        NULL,          // 工作目录
+        SW_SHOWNORMAL  // 显示方式
+    );
+
+    // 3. 释放内存
+    free(w_path);
+
+    // 检查是否成功
+    if ((INT_PTR)result <= 32) {
+      LOG_ERROR("Failed to open path: %s, error code: %jd", utf8_path, (intmax_t)(INT_PTR)result);
+    }
+}

--- a/src/iptux/UIHelperWindows.h
+++ b/src/iptux/UIHelperWindows.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void iptux_launch_file_windows(const char* utf8_path);

--- a/src/iptux/UiCoreThread.cpp
+++ b/src/iptux/UiCoreThread.cpp
@@ -13,7 +13,6 @@
 #include "UiCoreThread.h"
 
 #include <cinttypes>
-#include <sys/socket.h>
 #include <sys/stat.h>
 
 #include <glib/gi18n.h>

--- a/src/iptux/UiCoreThread.h
+++ b/src/iptux/UiCoreThread.h
@@ -17,7 +17,6 @@
 #ifndef IPTUX_UICORETHREAD_H
 #define IPTUX_UICORETHREAD_H
 
-#include <netinet/in.h>
 #include <queue>
 #include <sigc++/signal.h>
 

--- a/src/iptux/UiHelper.cpp
+++ b/src/iptux/UiHelper.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 #include "UiHelper.h"
 
+#include "UIHelperWindows.h"
 #include <atomic>
 #include <cerrno>
 #include <cstring>
@@ -20,6 +21,11 @@ static bool pop_disabled = false;
 
 void iptux_open_path(const char* path) {
   g_return_if_fail(!!path);
+
+#if defined(_WIN32)
+  iptux_launch_file_windows(path);
+  return;
+#endif
 
   GError* error = nullptr;
   gchar* uri = g_filename_to_uri(path, nullptr, &error);

--- a/src/iptux/UiHelper.cpp
+++ b/src/iptux/UiHelper.cpp
@@ -6,7 +6,6 @@
 #include <cstring>
 #include <ctime>
 #include <glib/gi18n.h>
-#include <sys/socket.h>
 
 #include "iptux-core/Models.h"
 #include "iptux-utils/output.h"
@@ -355,8 +354,13 @@ std::string TimeToStr(time_t t) {
 std::string TimeToStr_(time_t t, time_t now) {
   struct tm tm_t;
   struct tm tm_now;
+#if defined(_WIN32) || defined(_WIN64)
+  localtime_s(&tm_t, &t);
+  localtime_s(&tm_now, &now);
+#else
   localtime_r(&t, &tm_t);
   localtime_r(&now, &tm_now);
+#endif
   char res[11];
   if (tm_t.tm_year == tm_now.tm_year && tm_t.tm_yday == tm_now.tm_yday) {
     strftime(res, sizeof(res), "%H:%M", &tm_t);

--- a/src/iptux/UiHelper.h
+++ b/src/iptux/UiHelper.h
@@ -48,6 +48,7 @@ void pop_info(GtkWidget* parent, const gchar* format, ...) G_GNUC_PRINTF(2, 3);
 void pop_warning(GtkWidget* parent, const gchar* format, ...)
     G_GNUC_PRINTF(2, 3);
 void iptux_open_url(const char* url);
+void iptux_open_path(const char* path);
 void _ForTestToggleOpenUrl(bool enable);
 
 std::string ipv4_get_lan_name(in_addr ipv4);

--- a/src/iptux/UiHelper.h
+++ b/src/iptux/UiHelper.h
@@ -3,8 +3,8 @@
 
 #include <string>
 
-#include <arpa/inet.h>
 #include <gtk/gtk.h>
+#include "iptux-core/internal/iptux_network.h"
 
 namespace iptux {
 

--- a/src/iptux/UiHelperTest.cpp
+++ b/src/iptux/UiHelperTest.cpp
@@ -54,6 +54,7 @@ struct a {
   int res_height;
 };
 
+#if !defined(_WIN32) && !defined(_WIN64)
 TEST(UiHelper, igtk_image_new_with_size) {
   struct a cases[] = {
       {100, 100, 48, 48},
@@ -76,3 +77,4 @@ TEST(UiHelper, igtk_image_new_with_size) {
     g_object_unref(image);
   }
 }
+#endif

--- a/src/iptux/UiHelperTest.cpp
+++ b/src/iptux/UiHelperTest.cpp
@@ -15,6 +15,7 @@ TEST(UiHelper, markupEscapeText) {
   ASSERT_EQ(markupEscapeText("\"hello\""), "&quot;hello&quot;");
 }
 
+#if !defined(_WIN32) && !defined(_WIN64)
 TEST(UiHelper, TimeToStr) {
   setenv("TZ", "PST8PDT,M3.2.0/2,M11.1.0/2", 1);
   tzset();
@@ -32,6 +33,7 @@ TEST(UiHelper, TimeToStr) {
   ASSERT_EQ(TimeToStr_((1713583969 / 86400 + 1) * 86400, 1713583969),
             "2024-04-21");
 }
+#endif
 
 TEST(UiHelper, StrFirstNonEmptyLine) {
   ASSERT_EQ(StrFirstNonEmptyLine(""), "");

--- a/src/iptux/UiModels.cpp
+++ b/src/iptux/UiModels.cpp
@@ -10,7 +10,6 @@
 #include <cstring>
 #include <glib/gi18n.h>
 #include <inttypes.h>
-#include <netinet/in.h>
 #include <sstream>
 
 using namespace std;
@@ -744,7 +743,7 @@ static void InsertHeaderToBuffer(GtkTextBuffer* buffer,
                                                "me-color", NULL);
       g_free(header);
       break;
-    case MessageSourceType::ERROR:
+    case MessageSourceType::MST_ERROR:
       header = getformattime2(now, FALSE, "%s", _("<ERROR>"));
       gtk_text_buffer_get_end_iter(buffer, &iter);
       gtk_text_buffer_insert_with_tags_by_name(buffer, &iter, header, -1,

--- a/src/iptux/UiModelsTest.cpp
+++ b/src/iptux/UiModelsTest.cpp
@@ -79,6 +79,7 @@ TEST(GroupInfo, GetHintAsMarkup) {
             "size=\"smaller\">hello</span>");
 }
 
+#if !defined(_WIN32) && !defined(_WIN64)
 static string igtk_text_get_all_text(GtkTextBuffer* buffer) {
   GtkTextIter start, end;
   gtk_text_buffer_get_start_iter(buffer, &start);
@@ -119,6 +120,7 @@ TEST(GroupInfo, addMsgPara) {
       igtk_text_get_all_text(gi.buffer),
       "(06:55:06) palname:\nhelloworld\n(06:55:07) palname:\n\xEF\xBF\xBC\n");
 }
+#endif
 
 TEST(GroupInfo, genMsgParaFromInput) {
   PalInfo pal("127.0.0.1", 2425);

--- a/src/iptux/UiModelsTest.cpp
+++ b/src/iptux/UiModelsTest.cpp
@@ -71,7 +71,7 @@ TEST(GroupInfo, GetHintAsMarkup) {
             "Version: 1_iptux\nNickname: palname\nUser: \nHost: \nAddress: "
             "127.0.0.1\nCompatibility: Microsoft\nSystem coding: ");
 
-  cpal->sign = strdup("hello");
+  cpal->sign = g_strdup("hello");
   ASSERT_EQ(gi.GetHintAsMarkup(),
             "Version: 1_iptux\nNickname: palname\nUser: \nHost: \nAddress: "
             "127.0.0.1\nCompatibility: Microsoft\nSystem coding: "

--- a/src/iptux/callback.cpp
+++ b/src/iptux/callback.cpp
@@ -84,7 +84,7 @@ gchar* choose_file_with_preview(const gchar* title, GtkWidget* parent) {
 
   chooser = gtk_file_chooser_dialog_new(
       title, GTK_WINDOW(parent), GTK_FILE_CHOOSER_ACTION_OPEN, _("_Open"),
-      GTK_RESPONSE_ACCEPT, _("_Cancel"), GTK_RESPONSE_CANCEL, NULL);
+      GTK_RESPONSE_ACCEPT, _("_Cancel"), GTK_RESPONSE_CANCEL, nullptr);
   gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
   gtk_file_chooser_set_local_only(GTK_FILE_CHOOSER(chooser), TRUE);
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(chooser), FALSE);

--- a/src/iptux/meson.build
+++ b/src/iptux/meson.build
@@ -26,6 +26,11 @@ sources = files([
 ])
 dependencies = [gtk_dep, jsoncpp_dep, sigc_dep]
 
+if host_machine.system() == 'windows'
+    ws2_32 = cc.find_library('ws2_32')
+    dependencies += [ws2_32]
+endif
+
 if host_machine.system() == 'darwin'
     sources += ['AppIndicatorMac.mm']
     dependencies += [dependency('appleframeworks', modules: ['Cocoa'])]

--- a/src/iptux/meson.build
+++ b/src/iptux/meson.build
@@ -29,6 +29,7 @@ dependencies = [gtk_dep, jsoncpp_dep, sigc_dep]
 if host_machine.system() == 'windows'
     ws2_32 = cc.find_library('ws2_32')
     dependencies += [ws2_32]
+    sources += ['UiHelperWindows.cpp']
 endif
 
 if host_machine.system() == 'darwin'

--- a/src/main/iptux.cpp
+++ b/src/main/iptux.cpp
@@ -69,7 +69,11 @@ static string nowAsString() {
   char buffer[80];
 
   time(&rawtime);
+#if defined(_WIN32) || defined(_WIN64)
+  localtime_s(&timeinfo, &rawtime);
+#else
   localtime_r(&rawtime, &timeinfo);
+#endif
 
   strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", &timeinfo);
   return buffer;
@@ -139,7 +143,9 @@ static void dealLog(const IptuxConfig& config) {
 int main(int argc, char** argv) {
   int ret;
 
+#if !defined(_WIN32) && !defined(_WIN64)
   installCrashHandler();
+#endif
   setlocale(LC_ALL, "");
   bindtextdomain(GETTEXT_PACKAGE, __LOCALE_PATH);
   bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");

--- a/src/main/meson.build
+++ b/src/main/meson.build
@@ -1,15 +1,21 @@
 iptux_sources = files(['iptux.cpp'])
+link_args = []
+main_deps = [gtk_dep, jsoncpp_dep, thread_dep, sigc_dep]
 
 if host_machine.system() != 'windows'
     iptux_sources += files(['iptux_crash_utils.cpp'])
+    link_args += ['-ldl']
+else
+    ws2_32 = cc.find_library('ws2_32')
+    main_deps += [ws2_32]
 endif
 
 executable('iptux',
     iptux_sources,
     include_directories: inc,
-    dependencies: [gtk_dep, jsoncpp_dep, thread_dep, sigc_dep],
+    dependencies: main_deps,
     link_with: [libiptux],
     export_dynamic: true,
     install: true,
-    link_args: ['-ldl'],
+    link_args: link_args,
 )

--- a/src/main/meson.build
+++ b/src/main/meson.build
@@ -1,4 +1,9 @@
-iptux_sources = files(['iptux.cpp', 'iptux_crash_utils.cpp'])
+iptux_sources = files(['iptux.cpp'])
+
+if host_machine.system() != 'windows'
+    iptux_sources += files(['iptux_crash_utils.cpp'])
+endif
+
 executable('iptux',
     iptux_sources,
     include_directories: inc,


### PR DESCRIPTION
/close #69 

- [x] send/recv msg
- [x] send/recv image
- [x] send/recv file
- [x] send/recv dir
- [x] scan neighbors when start 
- [x] chat log / system log
- [x] crash problem

## Summary by Sourcery

Modernize time formatting and networking includes while aligning string allocation with GLib utilities.

Bug Fixes:
- Use GLib g_strdup for string duplication to ensure consistency with GLib memory management.

Enhancements:
- Replace gettimeofday/localtime-based timestamp generation with GLib GDateTime for log output.
- Introduce a cross-platform iptux_network.h header to centralize network-related includes for Windows and Unix-like systems.
- Clean up low-level networking includes from utility headers to reduce unnecessary dependencies.

Tests:
- Update UiModelsTest to use GLib g_strdup for test data string allocation.

## Summary by Sourcery

Add Windows support for building and running iptux, including network, file transfer, logging, and UI behavior adaptations, while tightening IP handling and error reporting across platforms.

New Features:
- Support compiling and running iptux on Windows via MSYS2/Clang, including Windows-specific socket and file opening behavior.
- Introduce Windows-specific helpers for opening files/paths from the UI and for handling case-insensitive string search.

Bug Fixes:
- Fix crashes and logging failures by checking file descriptor validity and write results for chat and system logs.
- Harden IP parsing and validation by replacing raw inet_pton/inet_ntop uses with GLib-based helpers and explicit IPv4 checks, returning explicit errors on invalid addresses.
- Avoid duplicate filenames and path handling issues by using GLib path utilities for splitting and joining paths across platforms.
- Resolve issues with file transfer progress and EOF handling by checking read/write results and treating zero-length reads correctly.

Enhancements:
- Abstract low-level networking headers and types into a shared iptux_network.h for cross-platform socket compatibility.
- Modernize many time-handling call sites to use thread-safe variants (localtime_r/localtime_s) and GLib GDateTime-based formatting.
- Refine file transfer logic to use GSocket/GOutputStream for receiving files and to add more detailed logging around send/receive failures.
- Rework AnalogFS path handling to use GLib path APIs, improving portability and robustness.
- Improve broadcast-address discovery to support Windows adapters via GetAdaptersAddresses while retaining Unix implementations.
- Extend CoreThread and TcpData to work directly with GSocket/GInetAddress, including structured error reporting via a new iptux_core error domain.
- Normalize message source typing and logging macros, and replace raw strdup/new with GLib g_strdup in several models and program data paths.
- Make tests and utilities more robust by using binary-safe file I/O and GLib-aware IP helpers.

Build:
- Update Meson build scripts and dependencies to link the correct Windows networking libraries (ws2_32, iphlpapi), conditionally build crash utilities, and relax some Clang warning flags for cross-platform builds.
- Modernize the Windows GitHub Actions workflow to use newer checkout and MSYS2/Clang toolchains, add required dependencies, and run a version check after tests.

CI:
- Refresh the Windows CI workflow to align with the new toolchain and build configuration and to verify the built binary runs on Windows.

Tests:
- Adjust core, UI, and utils tests to use the new IP helper functions, GLib string duplication, and to skip time- and path-dependent tests on Windows where necessary.