### PR TITLE
#511: the UI update should in the main loop

### DIFF
--- a/src/iptux/UiCoreThread.cpp
+++ b/src/iptux/UiCoreThread.cpp
@@ -117,7 +117,9 @@ struct UiCoreThreadCtx {
 
 static gboolean iptux_uithread_update_pal_to_list(gpointer data) {
   auto* ctx = (UiCoreThreadCtx*)data;
+  ctx->self->Lock();
   ctx->self->UpdatePalToListInUI(ctx->key);
+  ctx->self->Unlock();
   delete ctx;
   return G_SOURCE_REMOVE;
 }

--- a/src/iptux/UiCoreThread.cpp
+++ b/src/iptux/UiCoreThread.cpp
@@ -12,7 +12,6 @@
 #include "config.h"
 #include "UiCoreThread.h"
 
-#include <cinttypes>
 #include <sys/socket.h>
 #include <sys/stat.h>
 
@@ -111,6 +110,18 @@ void UiCoreThread::ClearAllPalFromList() {
   }
 }
 
+struct UiCoreThreadCtx {
+  UiCoreThread* self;
+  PalKey key;
+};
+
+static gboolean iptux_uithread_update_pal_to_list(gpointer data) {
+  auto* ctx = (UiCoreThreadCtx*)data;
+  ctx->self->UpdatePalToListInUI(ctx->key);
+  delete ctx;
+  return G_SOURCE_REMOVE;
+}
+
 /**
  * 通告指定的好友信息数据已经被更新(非UI线程安全).
  * @param ipv4 ipv4
@@ -121,7 +132,11 @@ void UiCoreThread::ClearAllPalFromList() {
  */
 void UiCoreThread::UpdatePalToList(PalKey palKey) {
   CoreThread::UpdatePalToList(palKey);
+  UiCoreThreadCtx* ctx = new UiCoreThreadCtx{this, palKey};
+  g_main_context_invoke(NULL, iptux_uithread_update_pal_to_list, ctx);
+}
 
+void UiCoreThread::UpdatePalToListInUI(PalKey palKey) {
   PPalInfo ppal;
   GroupInfo* grpinf;
   SessionAbstract* session;

--- a/src/iptux/UiCoreThread.h
+++ b/src/iptux/UiCoreThread.h
@@ -45,6 +45,7 @@ class UiCoreThread : public CoreThread {
 
   void ClearAllPalFromList() override;
   void UpdatePalToList(PalKey palKey) override;
+  void UpdatePalToListInUI(PalKey palKey);
   void UpdatePalToList(in_addr ipv4) override {
     UpdatePalToList(PalKey(ipv4, port()));
   }

--- a/src/iptux/UiCoreThreadTest.cpp
+++ b/src/iptux/UiCoreThreadTest.cpp
@@ -1,6 +1,7 @@
 #include "Application.h"
 #include "gtest/gtest.h"
 
+#include "iptux-utils/utils.h"
 #include "iptux/TestHelper.h"
 #include "iptux/UiCoreThread.h"
 
@@ -17,6 +18,7 @@ TEST(UiCoreThread, Constructor) {
   UiCoreThread* thread = new UiCoreThread(app, core);
   thread->setIgnoreTcpBindFailed(true);
   thread->start();
+  thread->UpdatePalToList(PalKey(inAddrFromString("127.0.0.1"), 2425));
   thread->stop();
   delete thread;
   DestroyApplication(app);


### PR DESCRIPTION
/close #511 

## Summary by Sourcery

Ensure updating pal entries in the UI is dispatched to the main thread for thread-safe UI refreshes.

Bug Fixes:
- Fix UI thread-safety issue by invoking pal list updates through the GLib main context instead of directly from the core thread.

Enhancements:
- Introduce a dedicated UiCoreThread context and helper callback to schedule pal list updates on the UI/main loop.