### PR TITLE
fix share dir problem for dev mode 

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -18,7 +18,7 @@ conf_data.set(
 if get_option('mode') == 'dev'
   conf_data.set(
     'SHARE_IPTUX_DIR',
-    join_paths(meson.current_source_dir(), '../share'),
+    join_paths(meson.current_source_dir(), '../share/iptux'),
   )
 elif get_option('mode') == 'portable'
   conf_data.set(


### PR DESCRIPTION
## Summary by Sourcery

Fix the share directory configuration for development mode so it points to the iptux-specific subdirectory.

Bug Fixes:
- Correct the dev mode SHARE_IPTUX_DIR path to use the iptux subdirectory instead of the generic share directory.

Build:
- Adjust Meson configuration to set the development mode share path to ../share/iptux.