### PR TITLE
GObject Introspection support phase 1: basic framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
       - name: test
         run: |
           xvfb-run -a meson test -C build --verbose --no-stdsplit
+          python3 src/iptux-gi/gi-test.py
       - name: lcov
         run: |
           lcov --ignore-errors mismatch --directory . --capture --output-file coverage.info; # capture coverage info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
         run: sudo meson install -C build
       - name: test
         env:
+          LD_LIBRARY_PATH: /usr/local/lib/x86_64-linux-gnu
           GI_TYPELIB_PATH: /usr/local/lib/x86_64-linux-gnu/girepository-1.0
         run: |
           xvfb-run -a meson test -C build --verbose --no-stdsplit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,8 @@ jobs:
       - name: install
         run: sudo meson install -C build
       - name: test
+        env:
+          GI_TYPELIB_PATH: /usr/local/lib/x86_64-linux-gnu/girepository-1.0
         run: |
           xvfb-run -a meson test -C build --verbose --no-stdsplit
           python3 src/iptux-gi/gi-test.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: >-
           brew install --display-times ${{ env.MAC_PKGS }}
       - name: meson
-        run: meson setup -Db_sanitize=address,undefined -Db_ndebug=true build
+        run: meson setup -Db_sanitize=address,undefined -Db_ndebug=true -Db_lundef=false build
       - name: build
         run: meson compile -C build
       - name: install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   DEB_PKGS: >-
     g++ meson appstream gettext libgtk-3-dev libglib2.0-dev
     libjsoncpp-dev libsigc++-2.0-dev libayatana-appindicator3-dev
-    gobject-introspection
+    gobject-introspection libgirepository1.0-dev
   DEB_TEST_PKGS: xvfb
   MAC_PKGS: >-
     meson appstream gettext gtk+3 jsoncpp gtk-mac-integration libsigc++@2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: >-
           brew install --display-times ${{ env.MAC_PKGS }}
       - name: meson
-        run: meson setup -Db_sanitize=address,undefined -Db_ndebug=true -Db_lundef=false build
+        run: meson setup build
       - name: build
         run: meson compile -C build
       - name: install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
     libjsoncpp-dev libsigc++-2.0-dev libayatana-appindicator3-dev
   DEB_TEST_PKGS: xvfb
   MAC_PKGS: >-
-    meson appstream gettext gtk+3 jsoncpp gtk-mac-integration libsigc++@2
+    meson appstream gettext gtk+3 jsoncpp gtk-mac-integration libsigc++@2 gobject-introspection
 
 jobs:
   build-on-mac:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,11 @@ env:
   DEB_PKGS: >-
     g++ meson appstream gettext libgtk-3-dev libglib2.0-dev
     libjsoncpp-dev libsigc++-2.0-dev libayatana-appindicator3-dev
+    gobject-introspection
   DEB_TEST_PKGS: xvfb
   MAC_PKGS: >-
-    meson appstream gettext gtk+3 jsoncpp gtk-mac-integration libsigc++@2 gobject-introspection
+    meson appstream gettext gtk+3 jsoncpp gtk-mac-integration libsigc++@2
+    gobject-introspection
 
 jobs:
   build-on-mac:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,6 +36,7 @@ jobs:
             mingw-w64-clang-x86_64-gettext-tools
             mingw-w64-clang-x86_64-appstream
             mingw-w64-clang-x86_64-7zip
+            mingw-w64-clang-x86_64-gobject-introspection
 
       - name: Configure
         run: meson setup build

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('iptux', 'cpp',
+project('iptux', ['c', 'cpp'],
     license: 'GPL2+',
     version: '0.10.0',
     meson_version: '>=0.53',

--- a/src/api/iptux-core/CoreThread.h
+++ b/src/api/iptux-core/CoreThread.h
@@ -33,6 +33,9 @@ const char* coreThreadErrToStr(enum CoreThreadErr err);
 
 class CoreThread {
  public:
+  typedef std::shared_ptr<CoreThread> Ptr;
+
+ public:
   explicit CoreThread(std::shared_ptr<ProgramData> data);
   virtual ~CoreThread();
 

--- a/src/api/iptux-core/CoreThread.h
+++ b/src/api/iptux-core/CoreThread.h
@@ -3,17 +3,16 @@
 
 #include <gio/gio.h>
 
-#include "iptux-core/Models.h"
-#include <atomic>
-#include <cstdint>
-#include <memory>
-#include <vector>
-
-#include <sigc++/signal.h>
-
 #include "iptux-core/Event.h"
+#include "iptux-core/Models.h"
 #include "iptux-core/ProgramData.h"
 #include "iptux-core/TransFileModel.h"
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <sigc++/signal.h>
+#include <vector>
 
 #ifdef SendMessage
 #undef SendMessage

--- a/src/api/iptux-core/CoreThread.h
+++ b/src/api/iptux-core/CoreThread.h
@@ -15,6 +15,10 @@
 #include "iptux-core/ProgramData.h"
 #include "iptux-core/TransFileModel.h"
 
+#ifdef SendMessage
+#undef SendMessage
+#endif
+
 namespace iptux {
 
 class TransAbstract;

--- a/src/api/iptux-core/CoreThread.h
+++ b/src/api/iptux-core/CoreThread.h
@@ -188,7 +188,9 @@ class CoreThread {
 
   void UpdateMyInfo();
   void SendBroadcastExit(PPalInfo pal);
+
   int GetOnlineCount() const;
+  void OnlineForEach(std::function<bool(PalInfo::Ptr)> callback) const;
 
   std::unique_ptr<TransFileModel> GetTransTaskStat(int taskId) const;
   std::vector<std::unique_ptr<TransFileModel>> listTransTasks() const;

--- a/src/api/iptux-core/CoreThread.h
+++ b/src/api/iptux-core/CoreThread.h
@@ -36,6 +36,7 @@ class CoreThread {
   typedef std::shared_ptr<CoreThread> Ptr;
 
  public:
+  explicit CoreThread(IptuxConfig::Ptr config);
   explicit CoreThread(std::shared_ptr<ProgramData> data);
   virtual ~CoreThread();
 

--- a/src/api/iptux-core/Models.h
+++ b/src/api/iptux-core/Models.h
@@ -220,6 +220,9 @@ class ChipData {
  */
 class MsgPara {
  public:
+  typedef std::shared_ptr<MsgPara> Ptr;
+
+ public:
   explicit MsgPara(CPPalInfo pal);
   ~MsgPara();
 

--- a/src/api/iptux-core/Models.h
+++ b/src/api/iptux-core/Models.h
@@ -18,6 +18,9 @@
 #include <json/json.h>
 #ifdef _WIN32
 #include <winsock2.h>
+#ifdef SendMessage
+#undef SendMessage
+#endif
 #else
 #include <netinet/in.h>
 #endif

--- a/src/iptux-core/CoreThread.cpp
+++ b/src/iptux-core/CoreThread.cpp
@@ -1202,6 +1202,19 @@ int CoreThread::GetOnlineCount() const {
   return res;
 }
 
+void CoreThread::OnlineForEach(
+    std::function<bool(PalInfo::Ptr)> callback) const {
+  Lock();
+  for (auto pal : pImpl->pallist) {
+    if (pal->isOnline()) {
+      if (!callback(pal)) {
+        break;
+      }
+    }
+  }
+  Unlock();
+}
+
 void CoreThread::SendDetectPacket(const string& ipv4) {
   SendDetectPacket(inAddrFromString(ipv4));
 }

--- a/src/iptux-core/CoreThread.cpp
+++ b/src/iptux-core/CoreThread.cpp
@@ -580,6 +580,9 @@ CoreThread::CoreThread(shared_ptr<ProgramData> data)
       .setCompatible(true);
 }
 
+CoreThread::CoreThread(IptuxConfig::Ptr config)
+    : CoreThread(make_shared<ProgramData>(config)) {}
+
 CoreThread::~CoreThread() {
   if (started) {
     stop();

--- a/src/iptux-core/internal/iptux_network.h
+++ b/src/iptux-core/internal/iptux_network.h
@@ -3,6 +3,9 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #include <iphlpapi.h>
+#ifdef SendMessage
+#undef SendMessage
+#endif
 #else
 #include <ifaddrs.h>
 #include <net/if.h>

--- a/src/iptux-gi/gi-test.py
+++ b/src/iptux-gi/gi-test.py
@@ -1,11 +1,20 @@
 import gi
 gi.require_version('Iptux', '1.0')
 from gi.repository import Iptux
+import time
 
 def main():
     config = Iptux.Config.new_from_fname("")
     core_thread = Iptux.Service.new(config)
     core_thread.start()
+
+    time.sleep(2)  # Wait for the core thread to initialize
+
+    print(dir(core_thread))  # List available methods and attributes
+    pals = core_thread.get_pals()
+    for x in pals:
+        print(f"Pal Info: {repr(x)}")
+
     core_thread.stop()
     print("CoreThread created successfully.")
 

--- a/src/iptux-gi/gi-test.py
+++ b/src/iptux-gi/gi-test.py
@@ -1,12 +1,18 @@
 import gi
 gi.require_version('Iptux', '1.0')
+gi.require_version('GLib', '2.0')
 from gi.repository import Iptux
+from gi.repository import GLib
 import time
 
 def main():
     config = Iptux.Config.new_from_fname("")
     core_thread = Iptux.Service.new(config)
+    #core_thread.set_log_level(GLib.LogLevelFlags.LEVEL_DEBUG)  # Set log level to DEBUG
+
     core_thread.start()
+
+
 
     time.sleep(2)  # Wait for the core thread to initialize
 

--- a/src/iptux-gi/gi-test.py
+++ b/src/iptux-gi/gi-test.py
@@ -1,5 +1,5 @@
 import gi
-gi.require_version('Iptux', '1.0')
+gi.require_version('Iptux', '0.10')
 gi.require_version('GLib', '2.0')
 from gi.repository import Iptux
 from gi.repository import GLib

--- a/src/iptux-gi/gi-test.py
+++ b/src/iptux-gi/gi-test.py
@@ -13,7 +13,10 @@ def main():
     print(dir(core_thread))  # List available methods and attributes
     pals = core_thread.get_pals()
     for x in pals:
-        print(f"Pal Info: {repr(x)}")
+        print(f"Pal Info: {x.to_string()}")  # Assuming to_string() method exists
+
+
+    core_thread.send_message(pals[0], "Hello from Python!")  # Send a message to the first pal
 
     core_thread.stop()
     print("CoreThread created successfully.")

--- a/src/iptux-gi/gi-test.py
+++ b/src/iptux-gi/gi-test.py
@@ -1,0 +1,13 @@
+import gi
+gi.require_version('Iptux', '1.0')
+from gi.repository import Iptux
+
+def main():
+    config = Iptux.Config.new_from_fname("")
+    core_thread = Iptux.Service.new(config)
+    core_thread.start()
+    core_thread.stop()
+    print("CoreThread created successfully.")
+
+if __name__ == "__main__":
+    main()

--- a/src/iptux-gi/gi-test.py
+++ b/src/iptux-gi/gi-test.py
@@ -18,6 +18,8 @@ def main():
 
     core_thread.send_message(pals[0], "Hello from Python!")  # Send a message to the first pal
 
+    core_thread.send_message_async(pals[0], "Hello from Python (async)!", callback=lambda *args: print("Async callback called with args:", args))
+
     core_thread.stop()
     print("CoreThread created successfully.")
 

--- a/src/iptux-gi/iptux-config.cpp
+++ b/src/iptux-gi/iptux-config.cpp
@@ -2,6 +2,8 @@
 #include "iptux-core/IptuxConfig.h"
 #include "iptux-priv.h"
 
+G_BEGIN_DECLS
+
 G_DEFINE_TYPE(IptuxConfig, iptux_config, G_TYPE_OBJECT)
 
 static void iptux_config_class_init(IptuxConfigClass* //klass
@@ -12,12 +14,10 @@ static void iptux_config_init(IptuxConfig* self) {
   self->config = nullptr;
 }
 
-
-extern "C" {
-
 IptuxConfig* iptux_config_new_from_fname(const char* fname) {
   IptuxConfig* self = IPTUX_CONFIG(g_object_new(IPTUX_TYPE_CONFIG, nullptr));
   self->config = iptux::IptuxConfig::newFromString(fname);
   return self;
 }
-}
+
+G_END_DECLS

--- a/src/iptux-gi/iptux-config.cpp
+++ b/src/iptux-gi/iptux-config.cpp
@@ -6,8 +6,16 @@ G_BEGIN_DECLS
 
 G_DEFINE_TYPE(IptuxConfig, iptux_config, G_TYPE_OBJECT)
 
-static void iptux_config_class_init(IptuxConfigClass* //klass
-    ) {
+static void iptux_config_class_init(IptuxConfigClass* klass) {
+  GObjectClass* gobject_class = G_OBJECT_CLASS(klass);
+  gobject_class->finalize = [](GObject* object) {
+    IptuxConfig* self = IPTUX_CONFIG(object);
+    if (self->config) {
+      delete self->config;
+      self->config = nullptr;
+    }
+    G_OBJECT_CLASS(iptux_config_parent_class)->finalize(object);
+  };
 }
 
 static void iptux_config_init(IptuxConfig* self) {
@@ -16,7 +24,8 @@ static void iptux_config_init(IptuxConfig* self) {
 
 IptuxConfig* iptux_config_new_from_fname(const char* fname) {
   IptuxConfig* self = IPTUX_CONFIG(g_object_new(IPTUX_TYPE_CONFIG, nullptr));
-  self->config = iptux::IptuxConfig::newFromString(fname);
+  self->config =
+      new iptux::IptuxConfig::Ptr(iptux::IptuxConfig::newFromString(fname));
   return self;
 }
 

--- a/src/iptux-gi/iptux-config.cpp
+++ b/src/iptux-gi/iptux-config.cpp
@@ -1,11 +1,6 @@
 #include "iptux-config.h"
 #include "iptux-core/IptuxConfig.h"
-
-
-struct _IptuxConfig {
-  GObject parent_instance;
-  iptux::IptuxConfig::Ptr config;
-};
+#include "iptux-priv.h"
 
 G_DEFINE_TYPE(IptuxConfig, iptux_config, G_TYPE_OBJECT)
 

--- a/src/iptux-gi/iptux-config.cpp
+++ b/src/iptux-gi/iptux-config.cpp
@@ -15,8 +15,9 @@ static void iptux_config_init(IptuxConfig* self) {
 
 extern "C" {
 
-IptuxConfig* iptux_config_new(void) {
-  return IPTUX_CONFIG(g_object_new(IPTUX_TYPE_CONFIG, nullptr));
+IptuxConfig* iptux_config_new_from_fname(const char* fname) {
+  IptuxConfig* self = IPTUX_CONFIG(g_object_new(IPTUX_TYPE_CONFIG, nullptr));
+  self->config = iptux::IptuxConfig::newFromString(fname);
+  return self;
 }
-
 }

--- a/src/iptux-gi/iptux-config.cpp
+++ b/src/iptux-gi/iptux-config.cpp
@@ -1,0 +1,27 @@
+#include "iptux-config.h"
+#include "iptux-core/IptuxConfig.h"
+
+
+struct _IptuxConfig {
+  GObject parent_instance;
+  iptux::IptuxConfig::Ptr config;
+};
+
+G_DEFINE_TYPE(IptuxConfig, iptux_config, G_TYPE_OBJECT)
+
+static void iptux_config_class_init(IptuxConfigClass* //klass
+    ) {
+}
+
+static void iptux_config_init(IptuxConfig* self) {
+  self->config = nullptr;
+}
+
+
+extern "C" {
+
+IptuxConfig* iptux_config_new(void) {
+  return IPTUX_CONFIG(g_object_new(IPTUX_TYPE_CONFIG, nullptr));
+}
+
+}

--- a/src/iptux-gi/iptux-config.h
+++ b/src/iptux-gi/iptux-config.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define IPTUX_TYPE_CONFIG (iptux_config_get_type())
+G_DECLARE_FINAL_TYPE(IptuxConfig, iptux_config, IPTUX, CONFIG, GObject)
+
+
+IptuxConfig* iptux_config_new(void);
+
+G_END_DECLS

--- a/src/iptux-gi/iptux-config.h
+++ b/src/iptux-gi/iptux-config.h
@@ -7,7 +7,6 @@ G_BEGIN_DECLS
 #define IPTUX_TYPE_CONFIG (iptux_config_get_type())
 G_DECLARE_FINAL_TYPE(IptuxConfig, iptux_config, IPTUX, CONFIG, GObject)
 
-
-IptuxConfig* iptux_config_new(void);
+IptuxConfig* iptux_config_new_from_fname(const char* fname);
 
 G_END_DECLS

--- a/src/iptux-gi/iptux-pal.cpp
+++ b/src/iptux-gi/iptux-pal.cpp
@@ -5,8 +5,16 @@ G_BEGIN_DECLS
 
 G_DEFINE_TYPE(IptuxPal, iptux_pal, G_TYPE_OBJECT)
 
-static void iptux_pal_class_init(IptuxPalClass* //klass
-    ) {
+static void iptux_pal_class_init(IptuxPalClass* klass) {
+  GObjectClass* gobject_class = G_OBJECT_CLASS(klass);
+  gobject_class->finalize = [](GObject* object) {
+    IptuxPal* self = IPTUX_PAL(object);
+    if (self->pal_info) {
+      delete self->pal_info;
+      self->pal_info = nullptr;
+    }
+    G_OBJECT_CLASS(iptux_pal_parent_class)->finalize(object);
+  };
 }
 
 static void iptux_pal_init(IptuxPal* self) {
@@ -16,7 +24,9 @@ static void iptux_pal_init(IptuxPal* self) {
 char* iptux_pal_to_string(IptuxPal* self) {
   g_return_val_if_fail(self && self->pal_info, nullptr);
 
-  std::string pal_str = self->pal_info->toString();
+  auto& pal_info = *(self->pal_info);
+
+  std::string pal_str = pal_info->toString();
   return g_strdup(pal_str.c_str());
 }
 

--- a/src/iptux-gi/iptux-pal.cpp
+++ b/src/iptux-gi/iptux-pal.cpp
@@ -1,7 +1,7 @@
 #include "iptux-pal.h"
 #include "iptux-priv.h"
 
-
+G_BEGIN_DECLS
 
 G_DEFINE_TYPE(IptuxPal, iptux_pal, G_TYPE_OBJECT)
 
@@ -19,3 +19,5 @@ char* iptux_pal_to_string(IptuxPal* self) {
   std::string pal_str = self->pal_info->toString();
   return g_strdup(pal_str.c_str());
 }
+
+G_END_DECLS

--- a/src/iptux-gi/iptux-pal.cpp
+++ b/src/iptux-gi/iptux-pal.cpp
@@ -13,7 +13,9 @@ static void iptux_pal_init(IptuxPal* self) {
   self->pal_info = nullptr;
 }
 
+char* iptux_pal_to_string(IptuxPal* self) {
+  g_return_val_if_fail(self && self->pal_info, nullptr);
 
-extern "C" {
-
+  std::string pal_str = self->pal_info->toString();
+  return g_strdup(pal_str.c_str());
 }

--- a/src/iptux-gi/iptux-pal.cpp
+++ b/src/iptux-gi/iptux-pal.cpp
@@ -1,0 +1,19 @@
+#include "iptux-pal.h"
+#include "iptux-priv.h"
+
+
+
+G_DEFINE_TYPE(IptuxPal, iptux_pal, G_TYPE_OBJECT)
+
+static void iptux_pal_class_init(IptuxPalClass* //klass
+    ) {
+}
+
+static void iptux_pal_init(IptuxPal* self) {
+  self->pal_info = nullptr;
+}
+
+
+extern "C" {
+
+}

--- a/src/iptux-gi/iptux-pal.h
+++ b/src/iptux-gi/iptux-pal.h
@@ -8,4 +8,6 @@ G_BEGIN_DECLS
 #define IPTUX_TYPE_PAL (iptux_pal_get_type())
 G_DECLARE_FINAL_TYPE(IptuxPal, iptux_pal, IPTUX, PAL, GObject)
 
+char* iptux_pal_to_string(IptuxPal* self);
+
 G_END_DECLS

--- a/src/iptux-gi/iptux-pal.h
+++ b/src/iptux-gi/iptux-pal.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "iptux-config.h"
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define IPTUX_TYPE_PAL (iptux_pal_get_type())
+G_DECLARE_FINAL_TYPE(IptuxPal, iptux_pal, IPTUX, PAL, GObject)
+
+G_END_DECLS

--- a/src/iptux-gi/iptux-priv.h
+++ b/src/iptux-gi/iptux-priv.h
@@ -1,9 +1,15 @@
 #pragma once
 
-#include <glib-object.h>
 #include "iptux-core/IptuxConfig.h"
+#include "iptux-core/Models.h"
+#include <glib-object.h>
 
 struct _IptuxConfig {
   GObject parent_instance;
   iptux::IptuxConfig::Ptr config;
+};
+
+struct _IptuxPal {
+  GObject parent_instance;
+  iptux::PalInfo::Ptr pal_info;
 };

--- a/src/iptux-gi/iptux-priv.h
+++ b/src/iptux-gi/iptux-priv.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <glib-object.h>
+#include "iptux-core/IptuxConfig.h"
+
+struct _IptuxConfig {
+  GObject parent_instance;
+  iptux::IptuxConfig::Ptr config;
+};

--- a/src/iptux-gi/iptux-priv.h
+++ b/src/iptux-gi/iptux-priv.h
@@ -6,10 +6,10 @@
 
 struct _IptuxConfig {
   GObject parent_instance;
-  iptux::IptuxConfig::Ptr config;
+  iptux::IptuxConfig::Ptr* config;
 };
 
 struct _IptuxPal {
   GObject parent_instance;
-  iptux::PalInfo::Ptr pal_info;
+  iptux::PalInfo::Ptr* pal_info;
 };

--- a/src/iptux-gi/iptux-service.cpp
+++ b/src/iptux-gi/iptux-service.cpp
@@ -1,17 +1,67 @@
 #include "iptux-service.h"
 #include "iptux-core/CoreThread.h"
+#include "iptux-priv.h"
 
 using namespace iptux;
+
+enum {
+  PROP_0,
+  PROP_CONFIG,
+  N_PROPERTIES,
+};
+
+static GParamSpec* obj_properties[N_PROPERTIES] = {
+    nullptr,
+};
 
 struct _IptuxService {
   GObject parent_instance;
   CoreThread::Ptr core_thread;
+  ::IptuxConfig* config;
 };
 
 G_DEFINE_TYPE(IptuxService, iptux_service, G_TYPE_OBJECT)
 
-static void iptux_service_class_init(IptuxServiceClass* //klass
-    ) {
+static void iptux_service_set_property(GObject* object,
+                                       guint property_id,
+                                       const GValue* value,
+                                       GParamSpec* pspec) {
+  IptuxService* self = IPTUX_SERVICE(object);
+
+  switch (property_id) {
+    case PROP_CONFIG:
+      self->config = static_cast<::IptuxConfig*>(g_value_get_pointer(value));
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
+      break;
+  }
+}
+
+static void iptux_service_constructed(GObject* object) {
+  IptuxService* self = IPTUX_SERVICE(object);
+
+  // 必须先调用父类的 constructed
+  G_OBJECT_CLASS(iptux_service_parent_class)->constructed(object);
+
+  // 💡 关键点：此时 self->config 已经被成功赋值，可以在这里使用它！
+  if (self->config) {
+    self->core_thread = std::make_shared<CoreThread>(self->config->config);
+  }
+}
+
+static void iptux_service_class_init(IptuxServiceClass* klass) {
+  GObjectClass* gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = iptux_service_set_property;
+  gobject_class->constructed = iptux_service_constructed;
+
+  obj_properties[PROP_CONFIG] = g_param_spec_pointer(
+      "config", "Config", "IptuxConfig instance",
+      static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+
+  g_object_class_install_properties(gobject_class, N_PROPERTIES,
+                                    obj_properties);
 }
 
 static void iptux_service_init(IptuxService* self) {
@@ -21,8 +71,8 @@ static void iptux_service_init(IptuxService* self) {
 
 extern "C" {
 
-IptuxService* iptux_service_new(void) {
-  return IPTUX_SERVICE(g_object_new(IPTUX_TYPE_SERVICE, nullptr));
+IptuxService* iptux_service_new(::IptuxConfig* config) {
+  return IPTUX_SERVICE(
+      g_object_new(IPTUX_TYPE_SERVICE, "config", config, nullptr));
 }
-
 }

--- a/src/iptux-gi/iptux-service.cpp
+++ b/src/iptux-gi/iptux-service.cpp
@@ -2,6 +2,7 @@
 #include "iptux-core/CoreThread.h"
 #include "iptux-pal.h"
 #include "iptux-priv.h"
+#include "iptux-utils/output.h"
 
 using namespace iptux;
 
@@ -146,4 +147,10 @@ gboolean iptux_service_send_message_finish(IptuxService*,
                                            GAsyncResult*,
                                            GError**) {
   return TRUE;
+}
+
+void iptux_service_set_log_level(IptuxService* self, GLogLevelFlags level) {
+  g_return_if_fail(self != nullptr && self->core_thread != nullptr);
+
+  Log::setLogLevel(static_cast<LogLevel>(level));
 }

--- a/src/iptux-gi/iptux-service.cpp
+++ b/src/iptux-gi/iptux-service.cpp
@@ -6,6 +6,8 @@
 
 using namespace iptux;
 
+G_BEGIN_DECLS
+
 enum {
   PROP_0,
   PROP_CONFIG,
@@ -43,10 +45,8 @@ static void iptux_service_set_property(GObject* object,
 static void iptux_service_constructed(GObject* object) {
   IptuxService* self = IPTUX_SERVICE(object);
 
-  // 必须先调用父类的 constructed
   G_OBJECT_CLASS(iptux_service_parent_class)->constructed(object);
 
-  // 💡 关键点：此时 self->config 已经被成功赋值，可以在这里使用它！
   if (self->config) {
     self->core_thread = std::make_shared<CoreThread>(self->config->config);
   }
@@ -154,3 +154,5 @@ void iptux_service_set_log_level(IptuxService* self, GLogLevelFlags level) {
 
   Log::setLogLevel(static_cast<LogLevel>(level));
 }
+
+G_END_DECLS

--- a/src/iptux-gi/iptux-service.cpp
+++ b/src/iptux-gi/iptux-service.cpp
@@ -1,5 +1,6 @@
 #include "iptux-service.h"
 #include "iptux-core/CoreThread.h"
+#include "iptux-pal.h"
 #include "iptux-priv.h"
 
 using namespace iptux;
@@ -68,9 +69,6 @@ static void iptux_service_init(IptuxService* self) {
   self->core_thread = 0;
 }
 
-
-extern "C" {
-
 IptuxService* iptux_service_new(::IptuxConfig* config) {
   return IPTUX_SERVICE(
       g_object_new(IPTUX_TYPE_SERVICE, "config", config, nullptr));
@@ -94,4 +92,21 @@ bool iptux_service_stop(IptuxService* self) {
   self->core_thread->stop();
   return true;
 }
+
+GArray* iptux_service_get_pals(IptuxService* self) {
+  if (!self || !self->core_thread) {
+    g_warning("IptuxService or core_thread is null");
+    return nullptr;
+  }
+
+  GArray* garray = g_array_new(FALSE, FALSE, sizeof(IptuxPal*));
+
+  self->core_thread->OnlineForEach([&](PPalInfo pal_info) {
+    IptuxPal* pal = IPTUX_PAL(g_object_new(IPTUX_TYPE_PAL, nullptr));
+    pal->pal_info = pal_info;
+    g_array_append_val(garray, pal);
+    return true;  // Continue iteration
+  });
+
+  return garray;
 }

--- a/src/iptux-gi/iptux-service.cpp
+++ b/src/iptux-gi/iptux-service.cpp
@@ -75,4 +75,23 @@ IptuxService* iptux_service_new(::IptuxConfig* config) {
   return IPTUX_SERVICE(
       g_object_new(IPTUX_TYPE_SERVICE, "config", config, nullptr));
 }
+
+bool iptux_service_start(IptuxService* self) {
+  if (!self || !self->core_thread) {
+    g_warning("IptuxService or core_thread is null");
+    return false;
+  }
+
+  return self->core_thread->start();
+}
+
+bool iptux_service_stop(IptuxService* self) {
+  if (!self || !self->core_thread) {
+    g_warning("IptuxService or core_thread is null");
+    return false;
+  }
+
+  self->core_thread->stop();
+  return true;
+}
 }

--- a/src/iptux-gi/iptux-service.cpp
+++ b/src/iptux-gi/iptux-service.cpp
@@ -1,0 +1,28 @@
+#include "iptux-service.h"
+#include "iptux-core/CoreThread.h"
+
+using namespace iptux;
+
+struct _IptuxService {
+  GObject parent_instance;
+  CoreThread::Ptr core_thread;
+};
+
+G_DEFINE_TYPE(IptuxService, iptux_service, G_TYPE_OBJECT)
+
+static void iptux_service_class_init(IptuxServiceClass* //klass
+    ) {
+}
+
+static void iptux_service_init(IptuxService* self) {
+  self->core_thread = 0;
+}
+
+
+extern "C" {
+
+IptuxService* iptux_service_new(void) {
+  return IPTUX_SERVICE(g_object_new(IPTUX_TYPE_SERVICE, nullptr));
+}
+
+}

--- a/src/iptux-gi/iptux-service.cpp
+++ b/src/iptux-gi/iptux-service.cpp
@@ -4,6 +4,10 @@
 #include "iptux-priv.h"
 #include "iptux-utils/output.h"
 
+#ifdef SendMessage
+#undef SendMessage
+#endif
+
 using namespace iptux;
 
 G_BEGIN_DECLS
@@ -20,7 +24,7 @@ static GParamSpec* obj_properties[N_PROPERTIES] = {
 
 struct _IptuxService {
   GObject parent_instance;
-  CoreThread::Ptr core_thread;
+  CoreThread::Ptr* core_thread;
   ::IptuxConfig* config;
 };
 
@@ -35,6 +39,7 @@ static void iptux_service_set_property(GObject* object,
   switch (property_id) {
     case PROP_CONFIG:
       self->config = static_cast<::IptuxConfig*>(g_value_get_pointer(value));
+      g_object_ref(self->config);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
@@ -48,7 +53,8 @@ static void iptux_service_constructed(GObject* object) {
   G_OBJECT_CLASS(iptux_service_parent_class)->constructed(object);
 
   if (self->config) {
-    self->core_thread = std::make_shared<CoreThread>(self->config->config);
+    self->core_thread = new std::shared_ptr<CoreThread>(
+        std::make_shared<CoreThread>(*self->config->config));
   }
 }
 
@@ -57,6 +63,18 @@ static void iptux_service_class_init(IptuxServiceClass* klass) {
 
   gobject_class->set_property = iptux_service_set_property;
   gobject_class->constructed = iptux_service_constructed;
+  gobject_class->finalize = [](GObject* object) {
+    IptuxService* self = IPTUX_SERVICE(object);
+    if (self->core_thread) {
+      delete self->core_thread;
+      self->core_thread = nullptr;
+    }
+    if (self->config) {
+      g_object_unref(self->config);
+      self->config = nullptr;
+    }
+    G_OBJECT_CLASS(iptux_service_parent_class)->finalize(object);
+  };
 
   obj_properties[PROP_CONFIG] = g_param_spec_pointer(
       "config", "Config", "IptuxConfig instance",
@@ -81,7 +99,9 @@ bool iptux_service_start(IptuxService* self) {
     return false;
   }
 
-  return self->core_thread->start();
+  auto& core_thread = *(self->core_thread);
+
+  return core_thread->start();
 }
 
 bool iptux_service_stop(IptuxService* self) {
@@ -90,7 +110,9 @@ bool iptux_service_stop(IptuxService* self) {
     return false;
   }
 
-  self->core_thread->stop();
+  auto& core_thread = *(self->core_thread);
+
+  core_thread->stop();
   return true;
 }
 
@@ -100,11 +122,13 @@ GArray* iptux_service_get_pals(IptuxService* self) {
     return nullptr;
   }
 
+  auto& core_thread = *(self->core_thread);
+
   GArray* garray = g_array_new(FALSE, FALSE, sizeof(IptuxPal*));
 
-  self->core_thread->OnlineForEach([&](PPalInfo pal_info) {
+  core_thread->OnlineForEach([&](PalInfo::Ptr pal_info) {
     IptuxPal* pal = IPTUX_PAL(g_object_new(IPTUX_TYPE_PAL, nullptr));
-    pal->pal_info = pal_info;
+    pal->pal_info = new PalInfo::Ptr(pal_info);
     g_array_append_val(garray, pal);
     return true;  // Continue iteration
   });
@@ -119,8 +143,8 @@ gboolean iptux_service_send_message(IptuxService* self,
   g_return_val_if_fail(self != nullptr && self->core_thread != nullptr &&
                            pal != nullptr && message != nullptr,
                        FALSE);
-
-  self->core_thread->SendMessage(pal->pal_info, std::string(message));
+  auto& core_thread = *(self->core_thread);
+  core_thread->SendMessage(*pal->pal_info, std::string(message));
   return TRUE;
 }
 
@@ -130,13 +154,15 @@ void iptux_service_send_message_async(IptuxService* self,
                                       GCancellable*,
                                       GAsyncReadyCallback callback,
                                       gpointer user_data) {
-  MsgPara::Ptr msgPara = std::make_shared<MsgPara>(pal->pal_info);
+  MsgPara::Ptr msgPara = std::make_shared<MsgPara>(*pal->pal_info);
 
   g_return_if_fail(self != nullptr && self->core_thread != nullptr &&
                    pal != nullptr && message != nullptr);
 
+  auto core_thread = *(self->core_thread);
+
   msgPara->dtlist.emplace_back(ChipData(std::string(message)));
-  self->core_thread->AsyncSendMsgPara(msgPara);
+  core_thread->AsyncSendMsgPara(msgPara);
 
   callback(G_OBJECT(self), NULL,
            user_data);  // Notify that the operation is complete

--- a/src/iptux-gi/iptux-service.cpp
+++ b/src/iptux-gi/iptux-service.cpp
@@ -110,3 +110,15 @@ GArray* iptux_service_get_pals(IptuxService* self) {
 
   return garray;
 }
+
+gboolean iptux_service_send_message(IptuxService* self,
+                                    IptuxPal* pal,
+                                    const gchar* message,
+                                    GError**) {
+  g_return_val_if_fail(self != nullptr && self->core_thread != nullptr &&
+                           pal != nullptr && message != nullptr,
+                       FALSE);
+
+  self->core_thread->SendMessage(pal->pal_info, std::string(message));
+  return TRUE;
+}

--- a/src/iptux-gi/iptux-service.cpp
+++ b/src/iptux-gi/iptux-service.cpp
@@ -122,3 +122,28 @@ gboolean iptux_service_send_message(IptuxService* self,
   self->core_thread->SendMessage(pal->pal_info, std::string(message));
   return TRUE;
 }
+
+void iptux_service_send_message_async(IptuxService* self,
+                                      IptuxPal* pal,
+                                      const gchar* message,
+                                      GCancellable*,
+                                      GAsyncReadyCallback callback,
+                                      gpointer user_data) {
+  MsgPara::Ptr msgPara = std::make_shared<MsgPara>(pal->pal_info);
+
+  g_return_if_fail(self != nullptr && self->core_thread != nullptr &&
+                   pal != nullptr && message != nullptr);
+
+  msgPara->dtlist.emplace_back(ChipData(std::string(message)));
+  self->core_thread->AsyncSendMsgPara(msgPara);
+
+  callback(G_OBJECT(self), NULL,
+           user_data);  // Notify that the operation is complete
+  return;
+}
+
+gboolean iptux_service_send_message_finish(IptuxService*,
+                                           GAsyncResult*,
+                                           GError**) {
+  return TRUE;
+}

--- a/src/iptux-gi/iptux-service.h
+++ b/src/iptux-gi/iptux-service.h
@@ -10,4 +10,7 @@ G_DECLARE_FINAL_TYPE(IptuxService, iptux_service, IPTUX, SERVICE, GObject)
 
 IptuxService* iptux_service_new(IptuxConfig* config);
 
+bool iptux_service_start(IptuxService* self);
+bool iptux_service_stop(IptuxService* self);
+
 G_END_DECLS

--- a/src/iptux-gi/iptux-service.h
+++ b/src/iptux-gi/iptux-service.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "iptux-config.h"
 #include <glib-object.h>
 
 G_BEGIN_DECLS
@@ -7,7 +8,6 @@ G_BEGIN_DECLS
 #define IPTUX_TYPE_SERVICE (iptux_service_get_type())
 G_DECLARE_FINAL_TYPE(IptuxService, iptux_service, IPTUX, SERVICE, GObject)
 
-
-IptuxService* iptux_service_new(void);
+IptuxService* iptux_service_new(IptuxConfig* config);
 
 G_END_DECLS

--- a/src/iptux-gi/iptux-service.h
+++ b/src/iptux-gi/iptux-service.h
@@ -63,4 +63,6 @@ gboolean iptux_service_send_message_finish(IptuxService* self,
                                            GAsyncResult* result,
                                            GError** error);
 
+void iptux_service_set_log_level(IptuxService* self, GLogLevelFlags level);
+
 G_END_DECLS

--- a/src/iptux-gi/iptux-service.h
+++ b/src/iptux-gi/iptux-service.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define IPTUX_TYPE_SERVICE (iptux_service_get_type())
+G_DECLARE_FINAL_TYPE(IptuxService, iptux_service, IPTUX, SERVICE, GObject)
+
+
+IptuxService* iptux_service_new(void);
+
+G_END_DECLS

--- a/src/iptux-gi/iptux-service.h
+++ b/src/iptux-gi/iptux-service.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "iptux-config.h"
+#include "iptux-pal.h"
 #include <glib-object.h>
 
 G_BEGIN_DECLS
@@ -22,5 +23,10 @@ bool iptux_service_stop(IptuxService* self);
  * Returns: (element-type IptuxPal) (transfer container): A #GArray of pals.
  */
 GArray* iptux_service_get_pals(IptuxService* self);
+
+gboolean iptux_service_send_message(IptuxService* self,
+                                    IptuxPal* pal,
+                                    const gchar* message,
+                                    GError** error);
 
 G_END_DECLS

--- a/src/iptux-gi/iptux-service.h
+++ b/src/iptux-gi/iptux-service.h
@@ -13,4 +13,14 @@ IptuxService* iptux_service_new(IptuxConfig* config);
 bool iptux_service_start(IptuxService* self);
 bool iptux_service_stop(IptuxService* self);
 
+/**
+ * iptux_service_get_pals:
+ * @self: An #IptuxService instance.
+ *
+ * Gets the list of pals.
+ *
+ * Returns: (element-type IptuxPal) (transfer container): A #GArray of pals.
+ */
+GArray* iptux_service_get_pals(IptuxService* self);
+
 G_END_DECLS

--- a/src/iptux-gi/iptux-service.h
+++ b/src/iptux-gi/iptux-service.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "gio/gio.h"
 #include "iptux-config.h"
 #include "iptux-pal.h"
 #include <glib-object.h>
@@ -28,5 +29,38 @@ gboolean iptux_service_send_message(IptuxService* self,
                                     IptuxPal* pal,
                                     const gchar* message,
                                     GError** error);
+
+/**
+ * iptux_service_send_message_async:
+ * @self: An #IptuxService instance.
+ * @pal: An #IptuxPal recipient.
+ * @message: The message string to send.
+ * @cancellable: (nullable): A #GCancellable or %NULL.
+ * @callback: (scope async) (closure user_data): A #GAsyncReadyCallback to call
+ * when the request is satisfied.
+ * @user_data: The data to pass to callback function.
+ *
+ * Asynchronously sends a message to a pal.
+ */
+void iptux_service_send_message_async(IptuxService* self,
+                                      IptuxPal* pal,
+                                      const gchar* message,
+                                      GCancellable* cancellable,
+                                      GAsyncReadyCallback callback,
+                                      gpointer user_data);
+
+/**
+ * iptux_service_send_message_finish:
+ * @self: An #IptuxService instance.
+ * @result: A #GAsyncResult provided in the callback.
+ * @error: A #GError location to store the error, or %NULL.
+ *
+ * Finishes the send message operation.
+ *
+ * Returns: %TRUE if the message was sent successfully, %FALSE otherwise.
+ */
+gboolean iptux_service_send_message_finish(IptuxService* self,
+                                           GAsyncResult* result,
+                                           GError** error);
 
 G_END_DECLS

--- a/src/iptux-gi/iptux.toml
+++ b/src/iptux-gi/iptux.toml
@@ -1,0 +1,12 @@
+[library]
+name = "Iptux"
+version = "1.0"
+browse_url = ""
+repository_url = ""
+website_url = ""
+authors = "Your Name"
+license = "GPL-2.0-or-later"
+description = "C++ Library wrapped with GObject Introspection"
+
+[theme]
+name = "basic"

--- a/src/iptux-gi/meson.build
+++ b/src/iptux-gi/meson.build
@@ -19,6 +19,6 @@ gir = gnome.generate_gir(libiptux_gi,
   namespace: 'Iptux',
   symbol_prefix: 'iptux',
   identifier_prefix: 'Iptux',
-  includes: ['GObject-2.0'],
+  includes: ['GObject-2.0', 'Gio-2.0'],
   install: true
 )

--- a/src/iptux-gi/meson.build
+++ b/src/iptux-gi/meson.build
@@ -2,7 +2,8 @@ gnome = import('gnome')
 
 gobject_dep = dependency('gobject-2.0')
 sigc_dep = dependency('sigc++-2.0')
-dependencies = [gobject_dep, sigc_dep]
+jsoncpp_dep = dependency('jsoncpp', version: '>=1.0')
+dependencies = [gobject_dep, sigc_dep, jsoncpp_dep]
 
 libsources = files('iptux-service.cpp', 'iptux-config.cpp', 'iptux-pal.cpp')
 libiptux_gi = shared_library('iptux-gi',

--- a/src/iptux-gi/meson.build
+++ b/src/iptux-gi/meson.build
@@ -4,7 +4,7 @@ gobject_dep = dependency('gobject-2.0')
 sigc_dep = dependency('sigc++-2.0')
 dependencies = [gobject_dep, sigc_dep]
 
-libsources = files('iptux-service.cpp')
+libsources = files('iptux-service.cpp', 'iptux-config.cpp')
 libiptux_gi = shared_library('iptux-gi',
   sources: libsources,
   dependencies: dependencies,
@@ -13,7 +13,7 @@ libiptux_gi = shared_library('iptux-gi',
 )
 
 gir = gnome.generate_gir(libiptux_gi,
-  sources: ['iptux-service.h', 'iptux-service.cpp'],
+  sources: ['iptux-service.h', 'iptux-service.cpp', 'iptux-config.h', 'iptux-config.cpp'],
   nsversion: '1.0',
   namespace: 'Iptux',
   symbol_prefix: 'iptux',

--- a/src/iptux-gi/meson.build
+++ b/src/iptux-gi/meson.build
@@ -13,9 +13,12 @@ libiptux_gi = shared_library('iptux-gi',
   link_with: [libiptux_core],
 )
 
+version_parts = meson.project_version().split('.')
+nsversion = version_parts[0] + '.' + version_parts[1]
+
 gir = gnome.generate_gir(libiptux_gi,
   sources: ['iptux-service.h', 'iptux-service.cpp', 'iptux-config.h', 'iptux-config.cpp', 'iptux-pal.h', 'iptux-pal.cpp'],
-  nsversion: '1.0',
+  nsversion: nsversion,
   namespace: 'Iptux',
   symbol_prefix: 'iptux',
   identifier_prefix: 'Iptux',

--- a/src/iptux-gi/meson.build
+++ b/src/iptux-gi/meson.build
@@ -4,7 +4,7 @@ gobject_dep = dependency('gobject-2.0')
 sigc_dep = dependency('sigc++-2.0')
 dependencies = [gobject_dep, sigc_dep]
 
-libsources = files('iptux-service.cpp', 'iptux-config.cpp')
+libsources = files('iptux-service.cpp', 'iptux-config.cpp', 'iptux-pal.cpp')
 libiptux_gi = shared_library('iptux-gi',
   sources: libsources,
   dependencies: dependencies,
@@ -14,7 +14,7 @@ libiptux_gi = shared_library('iptux-gi',
 )
 
 gir = gnome.generate_gir(libiptux_gi,
-  sources: ['iptux-service.h', 'iptux-service.cpp', 'iptux-config.h', 'iptux-config.cpp'],
+  sources: ['iptux-service.h', 'iptux-service.cpp', 'iptux-config.h', 'iptux-config.cpp', 'iptux-pal.h', 'iptux-pal.cpp'],
   nsversion: '1.0',
   namespace: 'Iptux',
   symbol_prefix: 'iptux',

--- a/src/iptux-gi/meson.build
+++ b/src/iptux-gi/meson.build
@@ -1,0 +1,23 @@
+gnome = import('gnome')
+
+gobject_dep = dependency('gobject-2.0')
+sigc_dep = dependency('sigc++-2.0')
+dependencies = [gobject_dep, sigc_dep]
+
+libsources = files('iptux-service.cpp')
+libiptux_gi = shared_library('iptux-gi',
+  sources: libsources,
+  dependencies: dependencies,
+  install: true,
+  include_directories: include_directories('..', '../api'),
+)
+
+gir = gnome.generate_gir(libiptux_gi,
+  sources: ['iptux-service.h', 'iptux-service.cpp'],
+  nsversion: '1.0',
+  namespace: 'Iptux',
+  symbol_prefix: 'iptux',
+  identifier_prefix: 'Iptux',
+  includes: ['GObject-2.0'],
+  install: true
+)

--- a/src/iptux-gi/meson.build
+++ b/src/iptux-gi/meson.build
@@ -10,6 +10,7 @@ libiptux_gi = shared_library('iptux-gi',
   dependencies: dependencies,
   install: true,
   include_directories: include_directories('..', '../api'),
+  link_with: [libiptux_core],
 )
 
 gir = gnome.generate_gir(libiptux_gi,

--- a/src/iptux-utils/output.cpp
+++ b/src/iptux-utils/output.cpp
@@ -24,7 +24,7 @@ using namespace std;
 
 namespace iptux {
 
-static LogLevel _level = LogLevel::WARN;
+static LogLevel _level = LogLevel::DEBUG;
 
 static string getThreadName() {
   ostringstream oss;

--- a/src/iptux-utils/output.cpp
+++ b/src/iptux-utils/output.cpp
@@ -24,7 +24,7 @@ using namespace std;
 
 namespace iptux {
 
-static LogLevel _level = LogLevel::DEBUG;
+static LogLevel _level = LogLevel::WARN;
 
 static string getThreadName() {
   ostringstream oss;

--- a/src/meson.build
+++ b/src/meson.build
@@ -62,5 +62,6 @@ configure_file(
 subdir('api')
 subdir('iptux-utils')
 subdir('iptux-core')
+subdir('iptux-gi')
 subdir('iptux')
 subdir('main')


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new GObject-based IptuxService library with introspection support and wire it into the build system.

New Features:
- Add a GObject IptuxService type that holds a CoreThread shared pointer and a constructor helper.
- Build and install a new shared library module iptux-gi along with a GObject Introspection GIR for the Iptux namespace.

Enhancements:
- Expose a CoreThread::Ptr shared pointer alias for easier sharing of CoreThread instances.
- Extend Meson project configuration to treat the project as both C and C++ and include the new iptux-gi subdirectory in the build.